### PR TITLE
Factory implementation

### DIFF
--- a/backtest_engine/backtest_low_level.py
+++ b/backtest_engine/backtest_low_level.py
@@ -12,11 +12,16 @@ from nautilus_trader.persistence.wranglers import TradeTickDataWrangler
 from nautilus_trader.test_kit.providers import TestDataProvider
 from nautilus_trader.test_kit.providers import TestInstrumentProvider
 
-from execution_algos.simple_execution_strategy import get_execution_algorithm
-from strategies.ema_strategy import get_trading_strategy
+from execution_algos import create_execution_algorithm
+from strategies import create_strategy
 
 
-def run_backtest() -> BacktestEngine:
+def run_backtest(
+    strategy_name: str = "ema_cross",
+    execution_algorithm_name: str = "simple",
+    strategy_kwargs: dict | None = None,
+    execution_algorithm_kwargs: dict | None = None,
+) -> BacktestEngine:
     """Run the low-level backtest and return the configured engine."""
     # Load stub test data
     provider = TestDataProvider()
@@ -47,12 +52,24 @@ def run_backtest() -> BacktestEngine:
     engine.add_instrument(ethusdt_binance)
     engine.add_data(ticks)
 
-    # Instantiate and add strategy
-    strategy = get_trading_strategy(ethusdt_binance.id)
+    strategy_options = dict(strategy_kwargs or {})
+    execution_options = dict(execution_algorithm_kwargs or {})
+
+    # Keep default behavior aligned with previous implementation.
+    if strategy_name == "ema_cross":
+        strategy_options.setdefault("instrument_id", ethusdt_binance.id)
+    if execution_algorithm_name == "simple":
+        execution_options.setdefault("exec_id", "MY_GENERIC_ALGO")
+
+    # Instantiate and add strategy from registry
+    strategy = create_strategy(strategy_name, **strategy_options)
     engine.add_strategy(strategy=strategy)
 
-    # Instantiate and add execution algorithm
-    exec_algorithm = get_execution_algorithm(exec_id="MY_GENERIC_ALGO")
+    # Instantiate and add execution algorithm from registry
+    exec_algorithm = create_execution_algorithm(
+        execution_algorithm_name,
+        **execution_options,
+    )
     engine.add_exec_algorithm(exec_algorithm)
 
     # Run the engine (from start to end of data)

--- a/execution_algos/__init__.py
+++ b/execution_algos/__init__.py
@@ -1,1 +1,47 @@
 """Execution algorithm package."""
+
+from importlib import import_module
+from collections.abc import Callable
+from typing import Any
+
+_EXEC_ALGORITHM_FACTORIES: dict[str, tuple[str, str]] = {
+    "simple": (
+        "execution_algos.simple_execution_strategy",
+        "get_execution_algorithm",
+    ),
+}
+
+
+def _resolve_execution_factory(algorithm_name: str) -> Callable[..., Any]:
+    module_path, factory_name = _EXEC_ALGORITHM_FACTORIES[algorithm_name]
+    module = import_module(module_path)
+    return getattr(module, factory_name)
+
+
+class ExecutionAlgorithmFactory:
+    """Factory for creating execution algorithm instances by name."""
+
+    @staticmethod
+    def create(algorithm_name: str, *args: Any, **kwargs: Any) -> Any:
+        try:
+            factory = _resolve_execution_factory(algorithm_name)
+        except KeyError as exc:
+            available = ", ".join(sorted(_EXEC_ALGORITHM_FACTORIES))
+            raise ValueError(
+                f"Unknown execution algorithm '{algorithm_name}'. "
+                f"Available algorithms: {available}"
+            ) from exc
+
+        return factory(*args, **kwargs)
+
+    @staticmethod
+    def available() -> tuple[str, ...]:
+        return tuple(sorted(_EXEC_ALGORITHM_FACTORIES))
+
+
+def create_execution_algorithm(algorithm_name: str, *args: Any, **kwargs: Any) -> Any:
+    """Create an execution algorithm using the registered algorithm name."""
+    return ExecutionAlgorithmFactory.create(algorithm_name, *args, **kwargs)
+
+
+__all__ = ["ExecutionAlgorithmFactory", "create_execution_algorithm"]

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,1 +1,44 @@
 """Trading strategy package."""
+
+from importlib import import_module
+from collections.abc import Callable
+from typing import Any
+
+_STRATEGY_FACTORIES: dict[str, tuple[str, str]] = {
+    "ema_cross": ("strategies.ema_strategy", "get_trading_strategy"),
+    "momentum": ("strategies.sample_momentum_strategy", "get_trading_strategy"),
+}
+
+
+def _resolve_strategy_factory(strategy_name: str) -> Callable[..., Any]:
+    module_path, factory_name = _STRATEGY_FACTORIES[strategy_name]
+    module = import_module(module_path)
+    return getattr(module, factory_name)
+
+
+class StrategyFactory:
+    """Factory for creating strategy instances by name."""
+
+    @staticmethod
+    def create(strategy_name: str, *args: Any, **kwargs: Any) -> Any:
+        try:
+            factory = _resolve_strategy_factory(strategy_name)
+        except KeyError as exc:
+            available = ", ".join(sorted(_STRATEGY_FACTORIES))
+            raise ValueError(
+                f"Unknown strategy '{strategy_name}'. Available strategies: {available}"
+            ) from exc
+
+        return factory(*args, **kwargs)
+
+    @staticmethod
+    def available() -> tuple[str, ...]:
+        return tuple(sorted(_STRATEGY_FACTORIES))
+
+
+def create_strategy(strategy_name: str, *args: Any, **kwargs: Any) -> Any:
+    """Create a strategy using the registered strategy name."""
+    return StrategyFactory.create(strategy_name, *args, **kwargs)
+
+
+__all__ = ["StrategyFactory", "create_strategy"]


### PR DESCRIPTION
This PR adds factories for the `strategies` and `execution_algos` modules. These are implemented in `backtest_engine/backtest_low_level.py` in order to make it more generalizable once new strategies/execution algorithms are added. This PR addresses [Issue #9](https://github.com/tonyhieu/agentic-trading-system/issues/9).

An article on the factory design pattern: https://refactoring.guru/design-patterns/factory-method