### PR TITLE
Cloud loop runner v2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+data/
+nts_env/
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,20 @@
-# Dockerfile for autonomous agents with data retrieval
+FROM python:3.12-slim
 
-FROM python:3.11-slim
+WORKDIR /app
 
-WORKDIR /workspace
-
-# Install system dependencies
+# Install system dependencies (git needed for snapshot push)
 RUN apt-get update && apt-get install -y \
     curl \
     git \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install AWS CLI
-RUN pip install --no-cache-dir awscli
+# Copy project files
+COPY . .
 
-# Create cache directory
-RUN mkdir -p /data-cache
+# Install uv and dependencies
+RUN pip install uv
+RUN uv sync
 
-# Copy scripts
-COPY scripts/ /scripts/
-RUN chmod +x /scripts/*.py
-
-# Set environment
-ENV PATH="/scripts:${PATH}" \
-    DATA_CACHE_DIR="/data-cache" \
-    PYTHONUNBUFFERED=1
-
-# Default command - list datasets
-CMD ["python", "/scripts/data_retriever.py", "list-datasets"]
+# Run the agent
+CMD ["uv", "run", "python", "main.py"]

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,4 @@
+# agent module
+from .loop_agent import CloudLoopAgent
+
+__all__ = ["CloudLoopAgent"]

--- a/agent/claude_api.py
+++ b/agent/claude_api.py
@@ -1,0 +1,48 @@
+"""
+agent/claude_api.py
+
+Handles communication with the Claude API.
+- call_claude: sends a prompt to Claude and returns a parsed JSON response
+"""
+
+import anthropic
+import json
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def call_claude(prompt: str) -> dict:
+    """
+    Send a prompt to Claude and return a parsed JSON response.
+    """
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise ValueError("ANTHROPIC_API_KEY not found in environment.")
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    message = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=8096,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    text_parts = []
+    for block in message.content:
+        if hasattr(block, "text"):
+            text_parts.append(block.text)
+
+    raw = "\n".join(text_parts).strip()
+
+    # Handle accidental markdown fences
+    if raw.startswith("```"):
+        lines = raw.split("\n")
+        lines = [l for l in lines if not l.strip().startswith("```")]
+        raw = "\n".join(lines).strip()
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Claude did not return valid JSON.\nRaw response:\n{raw}") from e

--- a/agent/loop_agent.py
+++ b/agent/loop_agent.py
@@ -1,0 +1,219 @@
+"""
+agent/loop_agent.py
+
+Autonomous agent for the agentic trading loop.
+Orchestrates one full iteration of:
+  1. Run backtest with latest strategy version
+  2. Summarize results
+  3. Build prompt with strategy code and backtest summary
+  4. Call Claude for improvements
+  5. Validate and save improved strategy as new versioned file
+  6. Save results and push to snapshots/ branch (disabled by default)
+     (GitHub Actions handles S3 upload automatically via SKILLS.md)
+"""
+
+import ast
+import importlib.util
+import json
+import os
+import subprocess
+from datetime import datetime
+
+from backtest_engine.databento_backtest import run_databento_backtest
+from agent.prompt_builder import summarize_backtest, build_prompt
+from agent.claude_api import call_claude
+
+
+class CloudLoopAgent:
+    """
+    Autonomous agent that iterates on a trading strategy using Claude.
+
+    Args:
+        strategy_name: Base name for the strategy (e.g. "databento_naive")
+        iteration: Current iteration number. Increment between runs.
+        strategy_path: Path to the strategy file to iterate on.
+    """
+
+    def __init__(self, strategy_name: str = "databento_naive", iteration: int = 1,
+                 strategy_path: str = "strategies/databento_naive_strategy/databento_naive_strategy.py"):
+        self.strategy_name = strategy_name
+        self.iteration = iteration
+        self.strategy_path = strategy_path
+        self.engine = None
+        self.summary = None
+        self.response = None
+
+    def run_once(self) -> dict:
+        """
+        Run one full agent iteration.
+        """
+        try:
+            print(f"\n{'='*50}")
+            print(f"AGENT ITERATION {self.iteration} — {self.strategy_name}")
+            print(f"{'='*50}")
+
+            # Step 1: Run backtest
+            self._run_backtest()
+
+            # Step 2: Call Claude for improvements
+            self._call_claude()
+
+            # Step 3: Update strategy code with Claude's suggestion
+            self._update_strategy()
+
+            # Step 4: Save snapshot (disabled by default)
+            # self.save_snapshot()
+
+            return self.response
+
+        finally:
+            # Cleanup
+            if self.engine is not None:
+                try:
+                    self.engine.dispose()
+                except Exception:
+                    pass
+                self.engine = None
+
+    def _run_backtest(self) -> None:
+        print("\n[1/3] Running backtest...")
+
+        # Find latest versioned strategy file
+        dir_path = os.path.dirname(self.strategy_path)
+        base_name = os.path.basename(self.strategy_path).replace(".py", "")
+        latest_version_path = os.path.join(dir_path, f"{base_name}_v{self.iteration - 1}.py")
+
+        if self.iteration > 1 and os.path.exists(latest_version_path):
+            # Copy latest version to original path so backtest engine picks it up
+            with open(latest_version_path, "r") as f:
+                latest_code = f.read()
+            with open(self.strategy_path, "w") as f:
+                f.write(latest_code)
+            print(f"      Using strategy version: v{self.iteration - 1}")
+        else:
+            print(f"      Using original strategy")
+
+        self.engine = run_databento_backtest(strategy_name=self.strategy_name)
+        self.summary = summarize_backtest(self.engine)
+        self.summary["strategy_name"] = self.strategy_name  # override with actual name
+        print(f"      Sharpe: {self.summary.get('sharpe_ratio')} | "
+              f"PnL: {self.summary.get('pnl_total')} | "
+              f"Win rate: {self.summary.get('win_rate')}")
+
+    def _call_claude(self) -> None:
+        print("\n[2/3] Calling Claude for improvements...")
+        with open(self.strategy_path, "r") as f:
+            strategy_code = f.read()
+        prompt = build_prompt(self.summary, strategy_code)
+        self.response = call_claude(prompt)
+        print(f"      Got {len(self.response.get('improvements', []))} improvement(s) "
+              f"and {len(self.response.get('execution_changes', []))} execution change(s)")
+        print("\n=== CLAUDE RESPONSE ===")
+        print(self.response)
+
+    def _update_strategy(self) -> None:
+        """
+        Write Claude's improved strategy code to a new versioned file.
+        Validates syntax, interface, and importability before saving.
+        Original file is never permanently modified.
+        """
+        print("\n[3/3] Saving new strategy version...")
+        new_code = self.response.get("new_strategy_code")
+
+        if not new_code:
+            print("      [WARN] No new code returned by Claude, skipping.")
+            return
+
+        # Validation 1: syntax check
+        try:
+            ast.parse(new_code)
+        except SyntaxError as e:
+            print(f"      [ERROR] Claude returned invalid syntax: {e}, skipping.")
+            return
+
+        # Validation 2: check get_trading_strategy still exists
+        tree = ast.parse(new_code)
+        function_names = [node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)]
+        if "get_trading_strategy" not in function_names:
+            print("      [ERROR] get_trading_strategy missing from new code, skipping.")
+            return
+
+        # Validation 3: try dynamic import
+        dir_path = os.path.dirname(self.strategy_path)
+        base_name = os.path.basename(self.strategy_path).replace(".py", "")
+        new_path = os.path.join(dir_path, f"{base_name}_v{self.iteration}.py")
+
+        with open(new_path, "w") as f:
+            f.write(new_code)
+
+        try:
+            spec = importlib.util.spec_from_file_location(f"{base_name}_v{self.iteration}", new_path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            if not hasattr(module, "get_trading_strategy"):
+                raise AttributeError("get_trading_strategy not found after import")
+            print(f"      Import validation passed.")
+        except Exception as e:
+            print(f"      [ERROR] Import validation failed: {e}, removing candidate.")
+            os.remove(new_path)
+            return
+
+        print(f"      New version saved to: {new_path}")
+
+    def save_snapshot(self) -> None:
+        """
+        Write results to strategies/ directory and push to a snapshots/ branch.
+        GitHub Actions will detect the push and upload to S3 automatically.
+        See SKILLS.md for the full snapshot system documentation.
+        Requires GIT_TOKEN env var with repo write permission.
+        """
+        print("\n[3/3] Saving snapshot via git push...")
+
+        versioned_name = f"{self.strategy_name}-v{self.iteration}"
+        strategy_dir = os.path.join("strategies", versioned_name, "results")
+        os.makedirs(strategy_dir, exist_ok=True)
+
+        # Write backtest results
+        results_path = os.path.join(strategy_dir, "backtest-results.json")
+        with open(results_path, "w") as f:
+            json.dump({
+                "strategy_name": self.summary.get("strategy_name", self.strategy_name),
+                "backtest_date": datetime.utcnow().isoformat() + "Z",
+                "iteration": self.iteration,
+                "performance": {
+                    "sharpe_ratio": self.summary.get("sharpe_ratio"),
+                    "pnl_total": self.summary.get("pnl_total"),
+                    "win_rate": self.summary.get("win_rate"),
+                    "sortino_ratio": self.summary.get("sortino_ratio"),
+                    "profit_factor": self.summary.get("profit_factor"),
+                    "expectancy": self.summary.get("expectancy"),
+                    "total_orders": self.summary.get("total_orders"),
+                    "total_positions": self.summary.get("total_positions"),
+                },
+                "claude_suggestions": self.response,
+            }, f, indent=2)
+
+        # Write Claude's suggestions
+        suggestions_path = os.path.join(strategy_dir, "claude-suggestions.json")
+        with open(suggestions_path, "w") as f:
+            json.dump(self.response, f, indent=2)
+
+        # Push to snapshots/ branch — GitHub Actions handles S3 upload
+        branch = f"snapshots/{versioned_name}"
+        token = os.environ.get("GIT_TOKEN")
+
+        if not token:
+            print(f"      [GIT_TOKEN not set — skipping git push]")
+            print(f"      Results written locally to: strategies/{versioned_name}/")
+            return
+
+        try:
+            subprocess.run(["git", "checkout", "-b", branch], check=True, capture_output=True)
+            subprocess.run(["git", "add", results_path, suggestions_path], check=True, capture_output=True)
+            subprocess.run(["git", "commit", "-m", f"Agent: iteration {self.iteration} results"],
+                           check=True, capture_output=True)
+            subprocess.run(["git", "push", "origin", branch], check=True, capture_output=True)
+            print(f"      Pushed to branch: {branch}")
+            print(f"      GitHub Actions will snapshot to S3 automatically.")
+        except subprocess.CalledProcessError as e:
+            print(f"      [ERROR] Git push failed: {e.stderr.decode().strip()}")

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1,0 +1,157 @@
+"""
+agent/prompt_builder.py
+
+Utilities for summarizing backtest results and building prompts for Claude.
+- summarize_backtest: extracts key metrics from a completed backtest engine
+- build_prompt: formats the summary into a prompt for Claude to suggest improvements
+"""
+
+from nautilus_trader.model.currencies import USDT
+
+
+def _safe_get(mapping, key: str, default="N/A"):
+    """
+    Safely get a value from a dict-like object and stringify it.
+    """
+    try:
+        if mapping is None:
+            return default
+        value = mapping.get(key, default)
+        return str(value)
+    except Exception:
+        return default
+
+
+def _safe_len(obj, default="N/A"):
+    """
+    Safely get len(obj).
+    """
+    try:
+        return len(obj)
+    except Exception:
+        return default
+
+
+def _get_total_orders(cache):
+    """
+    Safely get total orders from cache.
+    """
+    try:
+        if hasattr(cache, "orders"):
+            return len(cache.orders())
+    except Exception:
+        pass
+    return "N/A"
+
+
+def _get_total_positions(cache):
+    """
+    Try to estimate total positions as:
+      len(open positions) + len(closed positions)
+
+    Falls back to N/A if the current Nautilus version does not expose
+    these methods or the return values are not sized collections.
+    """
+    try:
+        open_positions = cache.positions_open() if hasattr(cache, "positions_open") else []
+        closed_positions = cache.positions_closed() if hasattr(cache, "positions_closed") else []
+        return len(open_positions) + len(closed_positions)
+    except Exception:
+        return "N/A"
+
+
+def summarize_backtest(engine) -> dict:
+    """
+    Extract a robust summary from a completed backtest engine.
+    This function is designed to degrade gracefully if some metrics
+    are unavailable in the installed Nautilus Trader version.
+    """
+    summary = {
+        "status": "completed",
+        "strategy_name": "unknown",
+        "execution_algorithm": "SimpleExecutionAlgorithm",
+        "total_orders": "N/A",
+        "total_positions": "N/A",
+        "pnl_total": "N/A",
+        "win_rate": "N/A",
+        "sortino_ratio": "N/A",
+        "profit_factor": "N/A",
+        "expectancy": "N/A",
+        "sharpe_ratio": "N/A",
+    }
+
+    try:
+        cache = engine.cache
+        analyzer = engine.portfolio.analyzer
+
+        # Cache-based metrics
+        summary["total_orders"] = _get_total_orders(cache)
+        summary["total_positions"] = _get_total_positions(cache)
+
+        # Analyzer-based metrics
+        try:
+            stats = analyzer.get_performance_stats_returns()
+        except Exception:
+            stats = None
+
+        try:
+            pnl_stats = analyzer.get_performance_stats_pnls(currency=USDT)
+        except Exception:
+            pnl_stats = None
+
+        summary["pnl_total"] = _safe_get(pnl_stats, "PnL (total)")
+        summary["win_rate"] = _safe_get(pnl_stats, "Win Rate")
+        summary["expectancy"] = _safe_get(pnl_stats, "Expectancy")
+
+        summary["sortino_ratio"] = _safe_get(stats, "Sortino Ratio (252 days)")
+        summary["profit_factor"] = _safe_get(stats, "Profit Factor")
+        summary["sharpe_ratio"] = _safe_get(stats, "Sharpe Ratio (252 days)")
+
+        return summary
+
+    except Exception as e:
+        summary["notes"] = f"Could not fully extract metrics: {e}"
+        return summary
+
+
+def build_prompt(summary: dict, strategy_code: str = "") -> str:
+    """
+    Format the backtest summary into a prompt for Claude.
+    Asks Claude to return structured JSON with weaknesses,
+    improvements, execution changes, and suggested parameters,
+    plus an improved version of the strategy code.
+    """
+    return f"""
+You are improving a trading execution strategy.
+
+Current strategy code:
+{strategy_code}
+
+Current backtest summary:
+{summary}
+
+Return your answer as STRICT JSON with the following structure:
+
+{{
+  "weaknesses": ["..."],
+  "improvements": ["..."],
+  "execution_changes": ["..."],
+  "parameters": {{
+    "param_name": "suggested_value"
+  }},
+  "new_strategy_code": "complete improved Python code here"
+}}
+
+Rules:
+- Base your answer only on the provided summary and code
+- Return the COMPLETE strategy file in new_strategy_code, not just the changes
+- Do NOT change the class name or get_trading_strategy function signature
+- Do NOT rename or remove the get_trading_strategy factory function
+- Do NOT introduce any new external dependencies or packages
+- Keep all imports compatible with nautilus_trader
+- Preserve all existing config fields already used by the backtest engine
+- Do NOT invent metrics that are not present
+- Do NOT include any explanation outside the JSON
+- Do NOT include markdown (no ```json)
+- Output ONLY valid JSON
+"""

--- a/backtest_engine/__init__.py
+++ b/backtest_engine/__init__.py
@@ -1,3 +1,4 @@
 from .backtest_low_level import run_backtest
+from .databento_backtest import run_databento_backtest
 
-__all__ = ["run_backtest"]
+__all__ = ["run_backtest", "run_databento_backtest"]

--- a/backtest_engine/databento_backtest.py
+++ b/backtest_engine/databento_backtest.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import random
+from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 
 from nautilus_trader.adapters.databento.loaders import DatabentoDataLoader
 from nautilus_trader.backtest.config import BacktestEngineConfig
 from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.core.data import Data
 from nautilus_trader.model import Money
 from nautilus_trader.model import TraderId
 from nautilus_trader.model import Venue
 from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.data import CustomData
+from nautilus_trader.model.data import DataType
+from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import OmsType
@@ -18,10 +25,55 @@ from nautilus_trader.model.identifiers import InstrumentId
 from nautilus_trader.model.instruments import Commodity
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
-from datetime import datetime
 
 from execution_algos import create_execution_algorithm
+from strategies.databento_synthetic_signal import SyntheticDatabentoSignal
 from strategies import create_strategy
+
+
+def _generate_synthetic_signal_data(
+    data_records: list[Data],
+    horizon: int,
+    noise_std: float,
+    seed: int,
+) -> list[CustomData]:
+    if horizon <= 0:
+        raise ValueError("`synthetic_signal_horizon` must be > 0")
+
+    if noise_std < 0:
+        raise ValueError("`synthetic_signal_noise_std` must be >= 0")
+
+    quotes_by_instrument: dict[InstrumentId, list[QuoteTick]] = defaultdict(list)
+    for record in data_records:
+        if isinstance(record, QuoteTick):
+            quotes_by_instrument[record.instrument_id].append(record)
+
+    if not quotes_by_instrument:
+        return []
+
+    rng = random.Random(seed)
+    generated: list[CustomData] = []
+
+    for instrument_quotes in quotes_by_instrument.values():
+        instrument_quotes.sort(key=lambda tick: tick.ts_event)
+
+        for idx in range(len(instrument_quotes) - horizon):
+            current = instrument_quotes[idx]
+            future = instrument_quotes[idx + horizon]
+
+            current_mid = (current.bid_price.as_double() + current.ask_price.as_double()) / 2.0
+            future_mid = (future.bid_price.as_double() + future.ask_price.as_double()) / 2.0
+            signal_value = (future_mid - current_mid) + rng.gauss(0.0, noise_std)
+
+            signal = SyntheticDatabentoSignal(
+                instrument_id=current.instrument_id,
+                value=signal_value,
+                ts_event=current.ts_event,
+                ts_init=current.ts_init,
+            )
+            generated.append(CustomData(data_type=DataType(SyntheticDatabentoSignal), data=signal))
+
+    return generated
 
 
 def run_databento_backtest(
@@ -33,6 +85,10 @@ def run_databento_backtest(
     execution_algorithm_kwargs: dict | None = None,
     skip_on_error: bool = True,
     include_trades: bool = False,
+    synthetic_signal_horizon: int = 10,
+    synthetic_signal_noise_std: float = 0.0,
+    synthetic_signal_seed: int = 7,
+    generate_synthetic_signals: bool | None = None,
 ) -> BacktestEngine:
     """
     Run a backtest using Databento data loaded from a .dbn.zst file.
@@ -57,6 +113,15 @@ def run_databento_backtest(
         Whether to skip malformed Databento records instead of failing.
     include_trades : bool, default False
         Whether to include trades while decoding the Databento file.
+    synthetic_signal_horizon : int, default 10
+        Lookahead horizon in quote ticks used for synthetic signal generation.
+    synthetic_signal_noise_std : float, default 0.0
+        Standard deviation of Gaussian noise added to synthetic signal values.
+    synthetic_signal_seed : int, default 7
+        Random seed for reproducible synthetic signal generation.
+    generate_synthetic_signals : bool | None, default None
+        If True, inject synthetic custom signals into the replay stream.
+        If None, signals are injected only for ``strategy_name='databento_synthetic_signal'``.
 
     Returns
     -------
@@ -159,6 +224,23 @@ def run_databento_backtest(
     if not data_records:
         raise ValueError("No market data records found after filtering records.")
 
+    if generate_synthetic_signals is None:
+        generate_synthetic_signals = strategy_name == "databento_synthetic_signal"
+
+    if generate_synthetic_signals:
+        synthetic_data = _generate_synthetic_signal_data(
+            data_records=data_records,
+            horizon=synthetic_signal_horizon,
+            noise_std=synthetic_signal_noise_std,
+            seed=synthetic_signal_seed,
+        )
+        if not synthetic_data:
+            raise ValueError(
+                "Synthetic signal generation produced no data. "
+                "Ensure QuoteTick data exists and reduce `synthetic_signal_horizon` if needed.",
+            )
+        data_records.extend(synthetic_data)
+
     # Add data
     engine.add_data(data_records)
 
@@ -167,6 +249,14 @@ def run_databento_backtest(
     if strategy_name == "databento_subscriber":
         strategy_options.setdefault("instrument_ids", list(instrument_ids) if instrument_ids else None)
     elif strategy_name == "databento_naive" and "instrument_id" not in strategy_options:
+        if instrument_ids and len(instrument_ids) > 0:
+            strategy_options.setdefault("instrument_id", instrument_ids[0])
+        else:
+            strategy_options.setdefault(
+                "instrument_id",
+                str(sorted(record_instruments, key=str)[0]),
+            )
+    elif strategy_name == "databento_synthetic_signal" and "instrument_id" not in strategy_options:
         if instrument_ids and len(instrument_ids) > 0:
             strategy_options.setdefault("instrument_id", instrument_ids[0])
         else:

--- a/backtest_engine/databento_backtest.py
+++ b/backtest_engine/databento_backtest.py
@@ -73,7 +73,7 @@ def run_databento_backtest(
     """
     # Resolve file path
     if dbn_file_path is None:
-        repo_root = Path(__file__).resolve().parents[2]
+        repo_root = Path(__file__).resolve().parents[1]
         dbn_file_path = repo_root / "data" / "glbx-mdp3-20260401.mbp-1.dbn.zst"
     else:
         dbn_file_path = Path(dbn_file_path).expanduser().resolve()
@@ -166,6 +166,14 @@ def run_databento_backtest(
     strategy_options = dict(strategy_kwargs or {})
     if strategy_name == "databento_subscriber":
         strategy_options.setdefault("instrument_ids", list(instrument_ids) if instrument_ids else None)
+    elif strategy_name == "databento_naive" and "instrument_id" not in strategy_options:
+        if instrument_ids and len(instrument_ids) > 0:
+            strategy_options.setdefault("instrument_id", instrument_ids[0])
+        else:
+            strategy_options.setdefault(
+                "instrument_id",
+                str(sorted(record_instruments, key=str)[0]),
+            )
 
     strategy = create_strategy(strategy_name, **strategy_options)
     engine.add_strategy(strategy=strategy)

--- a/backtest_engine/databento_backtest.py
+++ b/backtest_engine/databento_backtest.py
@@ -1,0 +1,195 @@
+"""Databento backtest engine for replaying market data from .dbn.zst files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nautilus_trader.adapters.databento.loaders import DatabentoDataLoader
+from nautilus_trader.backtest.config import BacktestEngineConfig
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.model import Money
+from nautilus_trader.model import TraderId
+from nautilus_trader.model import Venue
+from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import AssetClass
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.instruments import Commodity
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+from datetime import datetime
+
+from execution_algos import create_execution_algorithm
+from strategies import create_strategy
+
+
+def run_databento_backtest(
+    dbn_file_path: str | Path | None = None,
+    instrument_ids: list[str] | None = None,
+    strategy_name: str = "databento_subscriber",
+    execution_algorithm_name: str = "simple",
+    strategy_kwargs: dict | None = None,
+    execution_algorithm_kwargs: dict | None = None,
+    skip_on_error: bool = True,
+    include_trades: bool = False,
+) -> BacktestEngine:
+    """
+    Run a backtest using Databento data loaded from a .dbn.zst file.
+
+    Parameters
+    ----------
+    dbn_file_path : str | Path | None
+        Path to the Databento .dbn.zst file. If ``None``, defaults to
+        ``data/glbx-mdp3-20260401.mbp-1.dbn.zst``.
+    instrument_ids : list[str] | None
+        List of instrument IDs to filter by (e.g., ["ESM6.GLBX", "GCM6.GLBX"]).
+        If ``None``, all instruments from the file are used.
+    strategy_name : str, default "databento_subscriber"
+        The name of the strategy to instantiate from the registry.
+    execution_algorithm_name : str, default "simple"
+        The name of the execution algorithm to instantiate from the registry.
+    strategy_kwargs : dict | None
+        Additional keyword arguments to pass to the strategy factory.
+    execution_algorithm_kwargs : dict | None
+        Additional keyword arguments to pass to the execution algorithm factory.
+    skip_on_error : bool, default True
+        Whether to skip malformed Databento records instead of failing.
+    include_trades : bool, default False
+        Whether to include trades while decoding the Databento file.
+
+    Returns
+    -------
+    BacktestEngine
+        The configured and run backtest engine.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the specified Databento file does not exist.
+    ValueError
+        If no records are decoded from the file or instrument parsing fails.
+
+    """
+    # Resolve file path
+    if dbn_file_path is None:
+        repo_root = Path(__file__).resolve().parents[2]
+        dbn_file_path = repo_root / "data" / "glbx-mdp3-20260401.mbp-1.dbn.zst"
+    else:
+        dbn_file_path = Path(dbn_file_path).expanduser().resolve()
+
+    if not dbn_file_path.exists():
+        raise FileNotFoundError(f"Databento file not found: {dbn_file_path}")
+
+    # Load Databento records
+    loader = DatabentoDataLoader()
+    parsed_instrument_id = None
+    if instrument_ids and len(instrument_ids) == 1:
+        # If filtering to a single instrument, use the DatabentoDataLoader filter
+        try:
+            parsed_instrument_id = InstrumentId.from_str(instrument_ids[0])
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to parse instrument ID '{instrument_ids[0]}': {exc}"
+            ) from exc
+
+    records = loader.from_dbn_file(
+        path=str(dbn_file_path),
+        instrument_id=parsed_instrument_id,
+        as_legacy_cython=True,  # Use Cython objects that inherit from Data
+        include_trades=include_trades,
+        skip_on_error=skip_on_error,
+    )
+
+    if not records:
+        raise ValueError(
+            f"No records decoded from {dbn_file_path}. "
+            "Check file path and instrument filters."
+        )
+
+    # Extract unique instruments from records
+    record_instruments: set[InstrumentId] = set()
+    for record in records:
+        if hasattr(record, "instrument_id"):
+            record_instruments.add(record.instrument_id)
+
+    # Filter instruments if specified (for multiple instruments)
+    if instrument_ids and len(instrument_ids) > 1:
+        filter_ids = set(InstrumentId.from_str(iid) for iid in instrument_ids)
+        record_instruments = record_instruments.intersection(filter_ids)
+
+    if not record_instruments:
+        raise ValueError("No matching instruments found in records.")
+
+    # Configure and build backtest engine
+    config = BacktestEngineConfig(trader_id=TraderId("BACKTESTER-DATABENTO-001"))
+    engine = BacktestEngine(config=config)
+
+    # Add a trading venue (GLBX for CME Globex in this case)
+    venue = Venue("GLBX")
+    engine.add_venue(
+        venue=venue,
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.CASH,
+        base_currency=None,
+        starting_balances=[Money(1_000_000.0, USD)],
+    )
+
+    # Add instruments - create Commodity instruments for CME contracts
+    for instrument_id in record_instruments:
+        ts_now = int(datetime.utcnow().timestamp() * 1_000_000_000)
+        instrument = Commodity(
+            instrument_id=instrument_id,
+            raw_symbol=instrument_id.symbol,
+            asset_class=AssetClass.COMMODITY,
+            quote_currency=USD,
+            price_precision=2,
+            size_precision=0,
+            price_increment=Price(0.01, 2),
+            size_increment=Quantity(1, 0),
+            ts_event=ts_now,
+            ts_init=ts_now,
+        )
+        engine.add_instrument(instrument)
+
+    # Filter records to exclude Instrument objects (keep market data like QuoteTick, TradeTick, etc.)
+    # The DatabentoDataLoader returns a mix of market data and instrument definitions
+    data_records = [r for r in records if type(r).__name__ != "Instrument"]
+
+    if not data_records:
+        raise ValueError("No market data records found after filtering records.")
+
+    # Add data
+    engine.add_data(data_records)
+
+    # Instantiate and add strategy
+    strategy_options = dict(strategy_kwargs or {})
+    if strategy_name == "databento_subscriber":
+        strategy_options.setdefault("instrument_ids", list(instrument_ids) if instrument_ids else None)
+
+    strategy = create_strategy(strategy_name, **strategy_options)
+    engine.add_strategy(strategy=strategy)
+
+    # Instantiate and add execution algorithm
+    exec_options = dict(execution_algorithm_kwargs or {})
+    if execution_algorithm_name == "simple":
+        exec_options.setdefault("exec_id", "DATABENTO_GENERIC_ALGO")
+
+    exec_algorithm = create_execution_algorithm(execution_algorithm_name, **exec_options)
+    engine.add_exec_algorithm(exec_algorithm)
+
+    # Run the engine
+    engine.run()
+
+    # Generate reports
+    engine.trader.generate_account_report(venue)
+    engine.trader.generate_orders_report()
+    engine.trader.generate_order_fills_report()
+    engine.trader.generate_positions_report()
+
+    return engine
+
+
+if __name__ == "__main__":
+    backtest_engine = run_databento_backtest()
+    backtest_engine.dispose()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
-from backtest_engine.backtest_low_level import run_backtest
+# from backtest_engine.backtest_low_level import run_backtest
+from backtest_engine.databento_backtest import run_databento_backtest
 
 
 if __name__ == "__main__":
-    engine = run_backtest()
+    engine = run_databento_backtest(dbn_file_path="data/glbx-mdp3-20260401.mbp-1.dbn.zst")
     engine.dispose()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,26 @@
-# from backtest_engine.backtest_low_level import run_backtest
-from backtest_engine.databento_backtest import run_databento_backtest
+"""
+main.py
 
+Entry point for the CloudLoopAgent.
+
+Usage:
+    python main.py
+
+The agent runs multiple iterations of:
+  1. Backtest  →  2. Claude suggestions  →  3. Save versioned strategy
+"""
+
+import subprocess
+import sys
 
 if __name__ == "__main__":
-    engine = run_databento_backtest(dbn_file_path="data/glbx-mdp3-20260401.mbp-1.dbn.zst",
-                                    strategy_name="databento_naive")
-    engine.dispose()
+    NUM_ITERATIONS = 3
+
+    for i in range(1, NUM_ITERATIONS + 1):
+        subprocess.run(
+            [sys.executable, "-c",
+             f"from agent import CloudLoopAgent; "
+             f"agent = CloudLoopAgent(strategy_name='databento_naive', iteration={i}); "
+             f"agent.run_once()"],
+            check=False
+        )

--- a/main.py
+++ b/main.py
@@ -3,5 +3,6 @@ from backtest_engine.databento_backtest import run_databento_backtest
 
 
 if __name__ == "__main__":
-    engine = run_databento_backtest(dbn_file_path="data/glbx-mdp3-20260401.mbp-1.dbn.zst")
+    engine = run_databento_backtest(dbn_file_path="data/glbx-mdp3-20260401.mbp-1.dbn.zst",
+                                    strategy_name="databento_naive")
     engine.dispose()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "anthropic>=0.94.1",
+    "python-dotenv>=1.0.0",
     "dotenv>=0.9.9",
     "fsspec[http]>=2026.2.0",
     "matplotlib>=3.10.8",

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -8,6 +8,7 @@ _STRATEGY_FACTORIES: dict[str, tuple[str, str]] = {
     "ema_cross": ("strategies.ema_strategy", "get_trading_strategy"),
     "momentum": ("strategies.sample_momentum_strategy", "get_trading_strategy"),
     "databento_subscriber": ("strategies.databento_strategy", "get_trading_strategy"),
+    "databento_naive": ("strategies.databento_naive_strategy", "get_trading_strategy"),
 }
 
 

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 _STRATEGY_FACTORIES: dict[str, tuple[str, str]] = {
     "ema_cross": ("strategies.ema_strategy", "get_trading_strategy"),
     "momentum": ("strategies.sample_momentum_strategy", "get_trading_strategy"),
+    "databento_subscriber": ("strategies.databento_strategy", "get_trading_strategy"),
 }
 
 

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -9,6 +9,10 @@ _STRATEGY_FACTORIES: dict[str, tuple[str, str]] = {
     "momentum": ("strategies.sample_momentum_strategy", "get_trading_strategy"),
     "databento_subscriber": ("strategies.databento_strategy", "get_trading_strategy"),
     "databento_naive": ("strategies.databento_naive_strategy", "get_trading_strategy"),
+    "databento_synthetic_signal": (
+        "strategies.databento_synthetic_signal",
+        "get_trading_strategy",
+    ),
 }
 
 

--- a/strategies/databento_naive_strategy/__init__.py
+++ b/strategies/databento_naive_strategy/__init__.py
@@ -1,0 +1,3 @@
+from .databento_naive_strategy import get_trading_strategy
+
+__all__ = ["get_trading_strategy"]

--- a/strategies/databento_naive_strategy/databento_naive_strategy.py
+++ b/strategies/databento_naive_strategy/databento_naive_strategy.py
@@ -1,0 +1,175 @@
+"""Naive Databento trading strategy used to smoke-test the backtester."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import PositiveInt
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.data import Data
+from nautilus_trader.core.message import Event
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import PositionSide
+from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.identifiers import ExecAlgorithmId
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.instruments import Instrument
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.orders import MarketOrder
+from nautilus_trader.trading.strategy import Strategy
+
+
+class DatabentoNaiveStrategyConfig(StrategyConfig, frozen=True):
+    """Configuration for ``DatabentoNaiveStrategy`` instances."""
+
+    instrument_id: InstrumentId
+    trade_size: Decimal = Decimal("1")
+    signal_limit: PositiveInt = 50
+    exec_algorithm_id: ExecAlgorithmId | None = None
+    close_positions_on_stop: bool = True
+
+
+class DatabentoNaiveStrategy(Strategy):
+    """A deterministic tick-driven strategy for backtester smoke tests."""
+
+    def __init__(self, config: DatabentoNaiveStrategyConfig) -> None:
+        super().__init__(config)
+        self.instrument: Instrument | None = None
+        self._signal_count = 0
+        self._next_side = OrderSide.BUY
+
+    def on_start(self) -> None:
+        self.instrument = self.cache.instrument(self.config.instrument_id)
+        if self.instrument is None:
+            self.log.error(f"Instrument not found: {self.config.instrument_id}")
+            self.stop()
+            return
+
+        self.subscribe_quote_ticks(self.config.instrument_id)
+        self.log.info(
+            f"DatabentoNaiveStrategy started | instrument={self.config.instrument_id} | "
+            f"signal_limit={self.config.signal_limit}",
+            color=LogColor.GREEN,
+        )
+
+    def on_stop(self) -> None:
+        self.cancel_all_orders(self.config.instrument_id)
+        if self.config.close_positions_on_stop:
+            self.close_all_positions_via_exec_algorithm(self.config.instrument_id)
+
+        self.unsubscribe_quote_ticks(self.config.instrument_id)
+        self.log.info("DatabentoNaiveStrategy stopped.", color=LogColor.RED)
+
+    def on_reset(self) -> None:
+        self._signal_count = 0
+        self._next_side = OrderSide.BUY
+
+    def on_dispose(self) -> None:
+        pass
+
+    def on_save(self) -> dict[str, bytes]:
+        return {
+            "signal_count": str(self._signal_count).encode(),
+        }
+
+    def on_load(self, state: dict[str, bytes]) -> None:
+        signal_count = state.get("signal_count")
+
+        if signal_count is not None:
+            self._signal_count = int(signal_count.decode())
+
+        # Preserve deterministic alternation after restore.
+        self._next_side = OrderSide.BUY if self._signal_count % 2 == 0 else OrderSide.SELL
+
+    def on_quote_tick(self, tick: QuoteTick) -> None:
+        if tick.instrument_id != self.config.instrument_id:
+            return
+
+        self._emit_signal()
+
+    def on_trade_tick(self, tick: TradeTick) -> None:
+        pass
+
+    def on_data(self, data: Data) -> None:
+        pass
+
+    def on_event(self, event: Event) -> None:
+        pass
+
+    def _emit_signal(self) -> None:
+        if self._signal_count >= self.config.signal_limit:
+            return
+
+        if self.instrument is None:
+            self.log.warning("Instrument is not ready yet; skipping signal.")
+            return
+
+        order = self.order_factory.market(
+            instrument_id=self.config.instrument_id,
+            order_side=self._next_side,
+            quantity=self._make_qty(),
+            time_in_force=TimeInForce.GTC,
+            exec_algorithm_id=self.config.exec_algorithm_id,
+        )
+        self.log.info(
+            f"SIGNAL {self._next_side.value} {order.quantity} {self.config.instrument_id} "
+            f"[{self._signal_count + 1}/{self.config.signal_limit}]",
+            color=LogColor.MAGENTA if self._next_side == OrderSide.BUY else LogColor.CYAN,
+        )
+        self.submit_order(order)
+
+        self._signal_count += 1
+        self._next_side = OrderSide.SELL if self._next_side == OrderSide.BUY else OrderSide.BUY
+
+    def _make_qty(self) -> Quantity:
+        if self.instrument is None:
+            raise RuntimeError("Instrument is not available for quantity conversion.")
+        return self.instrument.make_qty(self.config.trade_size)
+
+    def close_all_positions_via_exec_algorithm(self, instrument_id: InstrumentId) -> None:
+        """Close open positions while preserving execution algorithm routing."""
+        positions_open = self.cache.positions_open(
+            venue=None,
+            instrument_id=instrument_id,
+            strategy_id=self.id,
+            side=PositionSide.NO_POSITION_SIDE,
+        )
+
+        if not positions_open:
+            return
+
+        for position in positions_open:
+            order: MarketOrder = self.order_factory.market(
+                instrument_id=position.instrument_id,
+                order_side=position.closing_order_side(),
+                quantity=position.quantity,
+                time_in_force=TimeInForce.GTC,
+                reduce_only=True,
+                exec_algorithm_id=self.config.exec_algorithm_id,
+            )
+            self.submit_order(order, position_id=position.id)
+
+
+def get_trading_strategy(
+    instrument_id: str | InstrumentId,
+    trade_size: Decimal = Decimal("1"),
+    signal_limit: int = 50,
+    exec_algorithm_id: str | None = "DATABENTO_GENERIC_ALGO",
+    close_positions_on_stop: bool = True,
+) -> DatabentoNaiveStrategy:
+    """Build and return a ``DatabentoNaiveStrategy`` instance."""
+    parsed_instrument_id = (
+        instrument_id if isinstance(instrument_id, InstrumentId) else InstrumentId.from_str(instrument_id)
+    )
+
+    config = DatabentoNaiveStrategyConfig(
+        instrument_id=parsed_instrument_id,
+        trade_size=trade_size,
+        signal_limit=signal_limit,
+        exec_algorithm_id=ExecAlgorithmId(exec_algorithm_id) if exec_algorithm_id else None,
+        close_positions_on_stop=close_positions_on_stop,
+    )
+    return DatabentoNaiveStrategy(config=config)

--- a/strategies/databento_strategy/__init__.py
+++ b/strategies/databento_strategy/__init__.py
@@ -1,0 +1,3 @@
+from .databento_strategy import get_trading_strategy
+
+__all__ = ["get_trading_strategy"]

--- a/strategies/databento_strategy/databento_strategy.py
+++ b/strategies/databento_strategy/databento_strategy.py
@@ -1,0 +1,228 @@
+"""Data subscriber strategy for ingesting and analyzing Databento data."""
+
+from __future__ import annotations
+
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.data import Data
+from nautilus_trader.core.message import Event
+from nautilus_trader.model.data import Bar
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.data import TradeTick
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.trading.strategy import Strategy
+
+
+class DataSubscriberConfig(StrategyConfig, frozen=True):
+    """
+    Configuration for ``DataSubscriber`` instances.
+
+    Parameters
+    ----------
+    instrument_ids : list[InstrumentId] | None
+        List of instrument IDs to subscribe to. If ``None``, no subscriptions
+        are made on start.
+
+    """
+
+    instrument_ids: list[InstrumentId] | None = None
+
+
+class DataSubscriber(Strategy):
+    """
+    A simple data subscriber strategy that ingests and logs market data.
+
+    This strategy subscribes to quote ticks, trade ticks, and order book data
+    for a configured set of instruments and logs all incoming data for analysis.
+
+    It does not generate trading signals or place orders.
+
+    Parameters
+    ----------
+    config : DataSubscriberConfig
+        The configuration for the instance.
+
+    """
+
+    def __init__(self, config: DataSubscriberConfig) -> None:
+        super().__init__(config)
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+
+    def on_start(self) -> None:
+        """
+        Actions to be performed when the strategy is started.
+
+        Subscribes to market data for all configured instruments.
+        """
+        if not self.config.instrument_ids:
+            self.log.warning("No instrument IDs configured for subscription.")
+            return
+
+        for instrument_id in self.config.instrument_ids:
+            self.subscribe_quote_ticks(instrument_id)
+            self.subscribe_trade_ticks(instrument_id)
+            # Uncomment to subscribe to order book updates:
+            # self.subscribe_order_book_deltas(instrument_id)
+
+        self.log.info(
+            f"DataSubscriber started | subscribed to {len(self.config.instrument_ids)} instruments",
+            color=LogColor.GREEN,
+        )
+
+    def on_stop(self) -> None:
+        """
+        Actions to be performed when the strategy is stopped.
+        """
+        if self.config.instrument_ids:
+            for instrument_id in self.config.instrument_ids:
+                self.unsubscribe_quote_ticks(instrument_id)
+                self.unsubscribe_trade_ticks(instrument_id)
+
+        self.log.info("DataSubscriber stopped.", color=LogColor.RED)
+
+    def on_reset(self) -> None:
+        """
+        Actions to be performed when the strategy is reset.
+        """
+        pass
+
+    def on_dispose(self) -> None:
+        """
+        Actions to be performed when the strategy is disposed.
+        """
+        pass
+
+    def on_save(self) -> dict[str, bytes]:
+        """
+        Actions to be performed when the strategy is saved.
+
+        Returns
+        -------
+        dict[str, bytes]
+            The strategy state dictionary (empty for this strategy).
+
+        """
+        return {}
+
+    def on_load(self, state: dict[str, bytes]) -> None:
+        """
+        Actions to be performed when the strategy is loaded.
+
+        Parameters
+        ----------
+        state : dict[str, bytes]
+            The strategy state dictionary.
+
+        """
+        pass
+
+    # ------------------------------------------------------------------
+    # Market data handlers
+    # ------------------------------------------------------------------
+
+    def on_quote_tick(self, tick: QuoteTick) -> None:
+        """
+        Actions to be performed when a quote tick is received.
+
+        Parameters
+        ----------
+        tick : QuoteTick
+            The quote tick received.
+
+        """
+        self.log.info(repr(tick), LogColor.CYAN)
+
+    def on_trade_tick(self, tick: TradeTick) -> None:
+        """
+        Actions to be performed when a trade tick is received.
+
+        Parameters
+        ----------
+        tick : TradeTick
+            The trade tick received.
+
+        """
+        self.log.info(repr(tick), LogColor.MAGENTA)
+
+    def on_bar(self, bar: Bar) -> None:
+        """
+        Actions to be performed when a bar is received.
+
+        Parameters
+        ----------
+        bar : Bar
+            The bar received.
+
+        """
+        self.log.info(repr(bar), LogColor.BLUE)
+
+    def on_data(self, data: Data) -> None:
+        """
+        Actions to be performed when generic data is received.
+
+        Parameters
+        ----------
+        data : Data
+            The data received.
+
+        """
+
+    def on_event(self, event: Event) -> None:
+        """
+        Actions to be performed when an event is received.
+
+        Parameters
+        ----------
+        event : Event
+            The event received.
+
+        """
+
+    def on_historical_data(self, data: Data) -> None:
+        """
+        Actions to be performed when historical data is received.
+
+        Parameters
+        ----------
+        data : Data
+            The historical data received.
+
+        """
+        self.log.info(repr(data), LogColor.CYAN)
+
+
+# ---------------------------------------------------------------------------
+# Factory helper – used by backtest_engine/databento_backtest.py
+# ---------------------------------------------------------------------------
+
+
+def get_trading_strategy(instrument_ids: list[str] | None = None) -> DataSubscriber:
+    """
+    Build and return a ``DataSubscriber`` instance for the given instruments.
+
+    Parameters
+    ----------
+    instrument_ids : list[str] | None
+        List of instrument ID strings to subscribe to (e.g., ["ESM6.GLBX", "GCM6.GLBX"]).
+        If ``None``, no instruments are subscribed on start.
+
+    Returns
+    -------
+    DataSubscriber
+
+    """
+    # Convert string instrument IDs to InstrumentId objects
+    parsed_instrument_ids = None
+    if instrument_ids:
+        try:
+            parsed_instrument_ids = [
+                InstrumentId.from_str(instr_id) for instr_id in instrument_ids
+            ]
+        except Exception as exc:
+            raise ValueError(f"Failed to parse instrument IDs: {exc}") from exc
+
+    config = DataSubscriberConfig(instrument_ids=parsed_instrument_ids)
+    return DataSubscriber(config=config)

--- a/strategies/databento_synthetic_signal/__init__.py
+++ b/strategies/databento_synthetic_signal/__init__.py
@@ -1,0 +1,4 @@
+from .databento_synthetic_signal import SyntheticDatabentoSignal
+from .databento_synthetic_signal import get_trading_strategy
+
+__all__ = ["SyntheticDatabentoSignal", "get_trading_strategy"]

--- a/strategies/databento_synthetic_signal/databento_synthetic_signal.py
+++ b/strategies/databento_synthetic_signal/databento_synthetic_signal.py
@@ -1,0 +1,184 @@
+"""Synthetic-signal Databento strategy for execution algorithm testing."""
+
+from decimal import Decimal
+
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import PositiveInt
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.data import Data
+from nautilus_trader.core.message import Event
+from nautilus_trader.model.data import DataType
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import PositionSide
+from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.identifiers import ExecAlgorithmId
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.instruments import Instrument
+from nautilus_trader.model.orders import MarketOrder
+from nautilus_trader.trading.strategy import Strategy
+
+
+class SyntheticDatabentoSignal(Data):
+    """A simple synthetic signal payload for Databento replay tests."""
+
+    def __init__(
+        self,
+        instrument_id: InstrumentId,
+        value: float,
+        ts_event: int,
+        ts_init: int,
+    ) -> None:
+        self.instrument_id = instrument_id
+        self.value = value
+        self._ts_event = ts_event
+        self._ts_init = ts_init
+
+    @property
+    def ts_event(self) -> int:
+        return self._ts_event
+
+    @property
+    def ts_init(self) -> int:
+        return self._ts_init
+
+
+class DatabentoSyntheticSignalStrategyConfig(StrategyConfig, frozen=True):
+    """Configuration for synthetic-signal Databento strategy instances."""
+
+    instrument_id: InstrumentId
+    trade_size: Decimal = Decimal("1")
+    signal_limit: PositiveInt = 50
+    signal_threshold: float = 0.0
+    exec_algorithm_id: ExecAlgorithmId | None = None
+    close_positions_on_stop: bool = True
+
+
+class DatabentoSyntheticSignalStrategy(Strategy):
+    """Submit market orders based on synthetic custom data signal values."""
+
+    def __init__(self, config: DatabentoSyntheticSignalStrategyConfig) -> None:
+        super().__init__(config)
+        self.instrument: Instrument | None = None
+        self._signal_count = 0
+
+    def on_start(self) -> None:
+        self.instrument = self.cache.instrument(self.config.instrument_id)
+        if self.instrument is None:
+            self.log.error(f"Instrument not found: {self.config.instrument_id}")
+            self.stop()
+            return
+
+        self.subscribe_data(
+            data_type=DataType(SyntheticDatabentoSignal),
+            instrument_id=self.config.instrument_id,
+        )
+        self.log.info(
+            f"DatabentoSyntheticSignalStrategy started | instrument={self.config.instrument_id} | "
+            f"signal_limit={self.config.signal_limit} | threshold={self.config.signal_threshold}",
+            color=LogColor.GREEN,
+        )
+
+    def on_stop(self) -> None:
+        self.cancel_all_orders(self.config.instrument_id)
+        if self.config.close_positions_on_stop:
+            self.close_all_positions_via_exec_algorithm(self.config.instrument_id)
+
+        self.unsubscribe_data(
+            data_type=DataType(SyntheticDatabentoSignal),
+            instrument_id=self.config.instrument_id,
+        )
+        self.log.info("DatabentoSyntheticSignalStrategy stopped.", color=LogColor.RED)
+
+    def on_reset(self) -> None:
+        self._signal_count = 0
+
+    def on_dispose(self) -> None:
+        pass
+
+    def on_save(self) -> dict[str, bytes]:
+        return {
+            "signal_count": str(self._signal_count).encode(),
+        }
+
+    def on_load(self, state: dict[str, bytes]) -> None:
+        signal_count = state.get("signal_count")
+        if signal_count is not None:
+            self._signal_count = int(signal_count.decode())
+
+    def on_data(self, data: Data) -> None:
+        if not isinstance(data, SyntheticDatabentoSignal):
+            return
+        if data.instrument_id != self.config.instrument_id:
+            return
+        if self._signal_count >= self.config.signal_limit:
+            return
+        if abs(data.value) <= self.config.signal_threshold:
+            return
+        if self.instrument is None:
+            return
+
+        side = OrderSide.BUY if data.value > 0 else OrderSide.SELL
+        order = self.order_factory.market(
+            instrument_id=self.config.instrument_id,
+            order_side=side,
+            quantity=self.instrument.make_qty(self.config.trade_size),
+            time_in_force=TimeInForce.GTC,
+            exec_algorithm_id=self.config.exec_algorithm_id,
+        )
+        self.log.info(
+            f"SYNTHETIC SIGNAL value={data.value:.6f} -> {side.value} {order.quantity} "
+            f"{self.config.instrument_id} [{self._signal_count + 1}/{self.config.signal_limit}]",
+            color=LogColor.MAGENTA if side == OrderSide.BUY else LogColor.CYAN,
+        )
+        self.submit_order(order)
+        self._signal_count += 1
+
+    def on_event(self, event: Event) -> None:
+        pass
+
+    def close_all_positions_via_exec_algorithm(self, instrument_id: InstrumentId) -> None:
+        """Close open positions while preserving execution algorithm routing."""
+        positions_open = self.cache.positions_open(
+            venue=None,
+            instrument_id=instrument_id,
+            strategy_id=self.id,
+            side=PositionSide.NO_POSITION_SIDE,
+        )
+
+        if not positions_open:
+            return
+
+        for position in positions_open:
+            order: MarketOrder = self.order_factory.market(
+                instrument_id=position.instrument_id,
+                order_side=position.closing_order_side(),
+                quantity=position.quantity,
+                time_in_force=TimeInForce.GTC,
+                reduce_only=True,
+                exec_algorithm_id=self.config.exec_algorithm_id,
+            )
+            self.submit_order(order, position_id=position.id)
+
+
+def get_trading_strategy(
+    instrument_id: str | InstrumentId,
+    trade_size: Decimal = Decimal("1"),
+    signal_limit: int = 50,
+    signal_threshold: float = 0.0,
+    exec_algorithm_id: str | None = "DATABENTO_GENERIC_ALGO",
+    close_positions_on_stop: bool = True,
+) -> DatabentoSyntheticSignalStrategy:
+    """Build and return a DatabentoSyntheticSignalStrategy instance."""
+    parsed_instrument_id = (
+        instrument_id if isinstance(instrument_id, InstrumentId) else InstrumentId.from_str(instrument_id)
+    )
+
+    config = DatabentoSyntheticSignalStrategyConfig(
+        instrument_id=parsed_instrument_id,
+        trade_size=trade_size,
+        signal_limit=signal_limit,
+        signal_threshold=signal_threshold,
+        exec_algorithm_id=ExecAlgorithmId(exec_algorithm_id) if exec_algorithm_id else None,
+        close_positions_on_stop=close_positions_on_stop,
+    )
+    return DatabentoSyntheticSignalStrategy(config=config)


### PR DESCRIPTION
Hi guys, update on the cloud loop runner!
What's new:
1. Moved all agent logic into its own agent/ module (with loop_agent.py, claude_api.py, prompt_builder.py, __init__.py)
2. Removed the demo file — it's no longer needed since the agent is now self-contained
3. Updated Dockerfile to use uv sync instead of pip
4. Added .dockerignore to exclude the data folder from the build 
5. Updated pyproject.toml with anthropic and python-dotenv dependencies

Current loop behavior:
backtest -> Claude analyzes results + current strategy code -> Claude returns improved strategy code -> saves as versioned file (databento_naive_strategy_v1.py, v2.py...) -> next iteration runs the latest version  (currently it may not work because of the new strategy may have some problem)

Notes:
Currently using single data file (glbx-mdp3-20260401.mbp-1.dbn.zst).
Claude-generated code occasionally has runtime errors that pass syntax check but fail during backtest (e.g. wrong API call types). 
For this question, my current plan is to add a smoke test validation layer: if the candidate code fails, the error is fed back to Claude for up to 3 retry attempts. If all retries fail, the agent falls back to the original strategy for the next iteration while carrying the failure history forward in the prompt, so Claude learns from previous mistakes over time. Still working on it.

Let me know if you have any questions!