### PR TITLE
fix: update Docker setup for Python 3.12 and NautilusTrader

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Python virtual environment
+.venv/
+env/
+venv/
+
+# Downloaded market data / outputs
+data-cache/
+snapshots/
+results/
+logs/
+
+# Secrets
+.env
+.env.*
+
+# Git
+.git/
+.gitignore
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# macOS
+.DS_Store
+
+# IDE
+.vscode/
+.idea/
+
+# Docker artifacts
+*.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,30 @@
-# Dockerfile for autonomous agents with data retrieval
+# Dockerfile for agentic trading system
+# Runs the NautilusTrader backtest engine with AWS S3 data retrieval
 
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /workspace
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
     curl \
     git \
-    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install AWS CLI
-RUN pip install --no-cache-dir awscli
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# Create cache directory
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+COPY . .
+
 RUN mkdir -p /data-cache
 
-# Copy scripts
-COPY scripts/ /scripts/
-RUN chmod +x /scripts/*.py
+ENV VIRTUAL_ENV="/workspace/.venv" \
+    PATH="/workspace/.venv/bin:${PATH}" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH="/workspace:/workspace/.venv/lib/python3.12/site-packages" \
+    DATA_CACHE_DIR="/data-cache"
 
-# Set environment
-ENV PATH="/scripts:${PATH}" \
-    DATA_CACHE_DIR="/data-cache" \
-    PYTHONUNBUFFERED=1
-
-# Default command - list datasets
-CMD ["python", "/scripts/data_retriever.py", "list-datasets"]
+CMD ["python", "main.py"]

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -791,6 +791,64 @@ python scripts/data_retriever.py fetch-manifest "$DATASET_NAME" "$VERSION"
 
 ---
 
-**Last Updated:** 2026-04-15  
+**Last Updated:** 2026-04-23 
 **System Version:** 1.0  
 **Retention Policy:** 30 days
+
+---
+
+# 🐳 Docker Execution Skill
+
+This section describes how to build and run the backtesting environment using Docker.
+
+## Why Docker?
+
+Docker ensures every agent runs in an identical, reproducible environment regardless of the host machine. All dependencies (NautilusTrader, pandas, AWS CLI) are pre-installed in the image.
+
+## Prerequisites
+
+- Docker installed
+- `.env` file with AWS credentials at repo root
+
+## Quick Start
+
+### Build the image
+
+```bash
+docker build -t agentic-trading .
+```
+
+### Run a backtest
+
+```bash
+docker-compose run --rm agent
+```
+
+### Run a single command
+
+```bash
+# Check Python version
+docker-compose run --rm agent python --version
+
+# Verify NautilusTrader is installed
+docker-compose run --rm agent python -c "import nautilus_trader; print('ok')"
+
+# Interactive shell for debugging
+docker-compose run --rm dev
+```
+
+## Services
+
+| Service | Purpose |
+|---------|---------|
+| `agent` | Runs full backtest via `python main.py` |
+| `dev` | Interactive bash shell for development |
+| `aws` | AWS CLI utility for S3 operations |
+
+## Data Caching
+
+Downloaded market data is persisted in `./data-cache/` and mounted into the container, so re-runs don't re-download data.
+
+## Environment Variables
+
+All credentials are loaded from `.env` file. See `.env.example` for required variables.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,49 +1,54 @@
-version: '3.8'
+version: "3.8"
 
 services:
-  # Autonomous agent with data retrieval capability
+
+  # Main agent: runs backtest and iterates on strategies
   agent:
     build:
       context: .
       dockerfile: Dockerfile
+    env_file: .env
     environment:
-      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_REGION: ${AWS_REGION:-us-east-2}
       S3_BUCKET_NAME: ${S3_BUCKET_NAME}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DATA_CACHE_DIR: /data-cache
     volumes:
-      - ./workspace:/workspace
-      - ./data-cache:/data-cache
-      - ./strategies:/strategies
+      - ./data-cache:/data-cache   # persist downloaded market data across runs
+      - .:/workspace               # agent can read/write strategy code and results
+    working_dir: /workspace
+    command: python main.py
+
+  # Interactive shell: develop and debug inside the full environment
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file: .env
+    environment:
+      AWS_REGION: ${AWS_REGION:-us-east-2}
+      S3_BUCKET_NAME: ${S3_BUCKET_NAME}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      DATA_CACHE_DIR: /data-cache
+    volumes:
+      - ./data-cache:/data-cache   # persist downloaded market data across runs
+      - .:/workspace               # live-reload source code without rebuilding
     working_dir: /workspace
     command: bash
 
-  # AWS CLI utility container
+  # AWS CLI utility: inspect and sync S3 directly
   aws:
     image: amazon/aws-cli:latest
+    env_file: .env
     environment:
-      AWS_REGION: ${AWS_REGION:-us-east-1}
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-    volumes:
-      - ./workspace:/workspace
-      - ./data-cache:/data-cache
-    working_dir: /workspace
-    entrypoint: aws
-
-  # Python development environment
-  dev:
-    image: python:3.11-slim
-    environment:
-      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_REGION: ${AWS_REGION:-us-east-2}
       S3_BUCKET_NAME: ${S3_BUCKET_NAME}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     volumes:
-      - ./workspace:/workspace
       - ./data-cache:/data-cache
-      - ./scripts:/scripts
-      - ./strategies:/strategies
+      - .:/workspace
     working_dir: /workspace
-    command: bash -c "pip install awscli pandas pyarrow && bash"
+    entrypoint: aws


### PR DESCRIPTION
Hi! Quick update on Docker setup — I’ve been improving the Docker environment so the container can run the backtest engine more reliably.

**Initial Issues**

* Project source code was not copied into the container
* Python 3.11 was used instead of the required 3.12
* Only `awscli` was installed, while project dependencies (including NautilusTrader) were missing

**Changes**

Updated `Dockerfile`:
- Python 3.11 → 3.12
- `uv sync` to install all deps from `uv.lock` (including NautilusTrader)
- `COPY . .` so project code is in the container
- Fixed `VIRTUAL_ENV`, `PYTHONPATH`, `PATH` for venv resolution

Updated `docker-compose.yml`
Added `.dockerignore` (build context: 1.18GB → 6.4MB)
Added Docker Execution Skill to `SKILLS.md`