### PR TITLE
Add oracle research strategy with offline pre-shifted signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ Thumbs.db
 *.bak
 temp/
 tmp/
+docs/oracle_strategy_implementation.md
+/NautilusDocs

--- a/backtest_engine/backtest_low_level.py
+++ b/backtest_engine/backtest_low_level.py
@@ -3,17 +3,21 @@ from pathlib import Path
 
 from nautilus_trader.backtest.config import BacktestEngineConfig
 from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.model import DataType
 from nautilus_trader.model import Money
 from nautilus_trader.model import TraderId
 from nautilus_trader.model import Venue
 from nautilus_trader.model.currencies import USD
+from nautilus_trader.model.data import CustomData
 from nautilus_trader.model.enums import AccountType
 from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.identifiers import ClientId
 
 from backtest_engine.data_loader import DATASET_NAME, DATASET_VERSION, load_dbn_partition
 from backtest_engine.results import Reports, compute_metrics, persist
 from execution_algos import create_execution_algorithm
 from strategies import create_strategy
+from strategies.databento_oracle_strategy import OracleSignal, build_oracle_signals
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 STARTING_BALANCE_USD = 1_000_000.0
@@ -55,8 +59,30 @@ def run_backtest(
 
     strategy_options = dict(strategy_kwargs or {})
     execution_options = dict(execution_algorithm_kwargs or {})
+    oracle_options: dict | None = None
 
     if strategy_name == "ema_cross":
+        strategy_options.setdefault("instrument_id", instrument.id)
+        strategy_options.setdefault("trade_size", Decimal("1"))
+    if strategy_name == "oracle":
+        # The oracle pipeline is split: preprocessing keys here are popped and
+        # used to generate OracleSignal data offline; whatever remains is passed
+        # straight through to the strategy factory.
+        oracle_options = {
+            "horizon_seconds": strategy_options.pop("horizon_seconds", 30.0),
+            "sigma": strategy_options.pop("sigma", 0.0),
+            "seed": strategy_options.pop("seed", 42),
+            "signal_interval_seconds": strategy_options.pop("signal_interval_seconds", 1.0),
+        }
+        signals = build_oracle_signals(ticks, **oracle_options)
+        # The DataEngine only routes custom Data subclasses through on_data
+        # when they're delivered as `CustomData(DataType, payload)` — raw
+        # subclass instances get dropped as "unrecognized type".
+        signal_data_type = DataType(OracleSignal)
+        wrapped_signals = [CustomData(signal_data_type, sig) for sig in signals]
+        engine.add_data(wrapped_signals, client_id=ClientId("ORACLE"))
+        print(f"Generated {len(signals)} oracle signals from {len(ticks)} ticks")
+
         strategy_options.setdefault("instrument_id", instrument.id)
         strategy_options.setdefault("trade_size", Decimal("1"))
     if execution_algorithm_name == "simple":
@@ -92,6 +118,8 @@ def run_backtest(
         "dataset_name": DATASET_NAME,
         "dataset_version": DATASET_VERSION,
     }
+    if oracle_options is not None:
+        metadata["oracle_preprocessing"] = oracle_options
 
     execution_dir_name = EXECUTION_DIRS.get(execution_algorithm_name, execution_algorithm_name)
     run_dir = persist(

--- a/main.py
+++ b/main.py
@@ -2,5 +2,14 @@ from backtest_engine.backtest_low_level import run_backtest
 
 
 if __name__ == "__main__":
-    engine = run_backtest()
+    engine = run_backtest(
+        strategy_name="oracle",
+        strategy_kwargs={
+            "horizon_seconds": 30.0,
+            "sigma": 0.1,
+            "signal_interval_seconds": 60.0,
+            "entry_threshold": 0.5,
+            "seed": 42,
+        },
+    )
     engine.dispose()

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 _STRATEGY_FACTORIES: dict[str, tuple[str, str]] = {
     "ema_cross": ("strategies.ema_strategy", "get_trading_strategy"),
     "momentum": ("strategies.sample_momentum_strategy", "get_trading_strategy"),
+    "oracle": ("strategies.databento_oracle_strategy", "get_trading_strategy"),
 }
 
 

--- a/strategies/databento_oracle_strategy/__init__.py
+++ b/strategies/databento_oracle_strategy/__init__.py
@@ -1,0 +1,15 @@
+from .oracle_signal import OracleSignal
+from .oracle_strategy import (
+    OracleStrategy,
+    OracleStrategyConfig,
+    get_trading_strategy,
+)
+from .preprocessing import build_oracle_signals
+
+__all__ = [
+    "OracleSignal",
+    "OracleStrategy",
+    "OracleStrategyConfig",
+    "build_oracle_signals",
+    "get_trading_strategy",
+]

--- a/strategies/databento_oracle_strategy/oracle_signal.py
+++ b/strategies/databento_oracle_strategy/oracle_signal.py
@@ -1,0 +1,49 @@
+"""Custom Nautilus data type carrying a pre-shifted "future" price.
+
+The signal is stamped at time T but carries the price observed at T + horizon
+(plus optional Gaussian noise). The shift is performed offline in
+``preprocessing.build_oracle_signals``, so the engine still sees a normally
+ordered stream by ``ts_init`` and ``OracleStrategy`` consumes the future price
+through ``on_data`` without any runtime look-ahead.
+
+The current price at T is embedded alongside the future price so the strategy's
+decision is fully self-contained and independent of cache state at the moment
+the signal is dispatched (ticks and signals at the same ``ts_init`` arrive in
+an order the engine controls; carrying both prices removes that ambiguity).
+"""
+from __future__ import annotations
+
+from nautilus_trader.core.data import Data
+from nautilus_trader.model.identifiers import InstrumentId
+
+
+class OracleSignal(Data):
+    def __init__(
+        self,
+        instrument_id: InstrumentId,
+        current_price: float,
+        future_price: float,
+        ts_event: int,
+        ts_init: int,
+    ) -> None:
+        self.instrument_id = instrument_id
+        self.current_price = current_price
+        self.future_price = future_price
+        self._ts_event = ts_event
+        self._ts_init = ts_init
+
+    @property
+    def ts_event(self) -> int:
+        return self._ts_event
+
+    @property
+    def ts_init(self) -> int:
+        return self._ts_init
+
+    def __repr__(self) -> str:
+        return (
+            f"OracleSignal(instrument_id={self.instrument_id}, "
+            f"current={self.current_price:.4f}, "
+            f"future={self.future_price:.4f}, "
+            f"ts_init={self._ts_init})"
+        )

--- a/strategies/databento_oracle_strategy/oracle_strategy.py
+++ b/strategies/databento_oracle_strategy/oracle_strategy.py
@@ -1,0 +1,168 @@
+"""Oracle trading strategy.
+
+Consumes pre-shifted ``OracleSignal`` custom data and trades the comparison
+between the embedded current price and the (noisy) future price. Designed as a
+research harness: holds signal quality constant (via the noise sigma chosen at
+preprocessing time) so the variable under study is the execution algorithm.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.data import Data
+from nautilus_trader.model import DataType
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import PositionSide
+from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.identifiers import ExecAlgorithmId
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.instruments import Instrument
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.orders import MarketOrder
+from nautilus_trader.trading.strategy import Strategy
+
+from strategies.databento_oracle_strategy.oracle_signal import OracleSignal
+
+
+class OracleStrategyConfig(StrategyConfig, frozen=True):
+    instrument_id: InstrumentId
+    trade_size: Decimal
+    entry_threshold: float = 0.5
+    exec_algorithm_id: ExecAlgorithmId | None = None
+    close_positions_on_stop: bool = True
+
+
+class OracleStrategy(Strategy):
+    """Long when the future price beats current by ``entry_threshold``, short on the inverse."""
+
+    def __init__(self, config: OracleStrategyConfig) -> None:
+        super().__init__(config)
+        self.instrument: Instrument | None = None
+
+    def on_start(self) -> None:
+        self.instrument = self.cache.instrument(self.config.instrument_id)
+        if self.instrument is None:
+            self.log.error(f"Instrument not found: {self.config.instrument_id}")
+            self.stop()
+            return
+
+        # Custom data is delivered to ``on_data`` only after subscribing — even
+        # for items injected via ``BacktestEngine.add_data``. The topic
+        # published by the data engine includes the instrument_id, so the
+        # subscription must match (otherwise no delivery).
+        self.subscribe_data(
+            DataType(OracleSignal),
+            instrument_id=self.config.instrument_id,
+        )
+
+        self.log.info(
+            f"OracleStrategy started | threshold={self.config.entry_threshold}",
+            color=LogColor.GREEN,
+        )
+
+    def on_stop(self) -> None:
+        self.cancel_all_orders(self.config.instrument_id)
+        if self.config.close_positions_on_stop:
+            self._close_all_positions()
+        self.unsubscribe_data(
+            DataType(OracleSignal),
+            instrument_id=self.config.instrument_id,
+        )
+        self.log.info("OracleStrategy stopped.", color=LogColor.RED)
+
+    def on_reset(self) -> None:
+        pass
+
+    def on_data(self, data: Data) -> None:
+        if not isinstance(data, OracleSignal):
+            return
+        if data.instrument_id != self.config.instrument_id:
+            return
+
+        edge = data.future_price - data.current_price
+
+        if edge > self.config.entry_threshold:
+            if self.portfolio.is_flat(self.config.instrument_id):
+                self._buy()
+            elif self.portfolio.is_net_short(self.config.instrument_id):
+                self._close_all_positions()
+                self._buy()
+        elif edge < -self.config.entry_threshold:
+            if self.portfolio.is_flat(self.config.instrument_id):
+                self._sell()
+            elif self.portfolio.is_net_long(self.config.instrument_id):
+                self._close_all_positions()
+                self._sell()
+
+    def _buy(self) -> None:
+        order: MarketOrder = self.order_factory.market(
+            instrument_id=self.config.instrument_id,
+            order_side=OrderSide.BUY,
+            quantity=self._make_qty(),
+            time_in_force=TimeInForce.GTC,
+            exec_algorithm_id=self.config.exec_algorithm_id,
+        )
+        self.log.info(
+            f"BUY {order.quantity} {self.config.instrument_id}",
+            color=LogColor.GREEN,
+        )
+        self.submit_order(order)
+
+    def _sell(self) -> None:
+        order: MarketOrder = self.order_factory.market(
+            instrument_id=self.config.instrument_id,
+            order_side=OrderSide.SELL,
+            quantity=self._make_qty(),
+            time_in_force=TimeInForce.GTC,
+            exec_algorithm_id=self.config.exec_algorithm_id,
+        )
+        self.log.info(
+            f"SELL {order.quantity} {self.config.instrument_id}",
+            color=LogColor.RED,
+        )
+        self.submit_order(order)
+
+    def _close_all_positions(self) -> None:
+        positions_open = self.cache.positions_open(
+            venue=None,
+            instrument_id=self.config.instrument_id,
+            strategy_id=self.id,
+            side=PositionSide.NO_POSITION_SIDE,
+        )
+        if not positions_open:
+            return
+        for position in positions_open:
+            order: MarketOrder = self.order_factory.market(
+                instrument_id=position.instrument_id,
+                order_side=position.closing_order_side(),
+                quantity=position.quantity,
+                time_in_force=TimeInForce.GTC,
+                reduce_only=True,
+                exec_algorithm_id=self.config.exec_algorithm_id,
+            )
+            self.log.info(
+                f"CLOSE {order.quantity} {position.instrument_id}",
+                color=LogColor.YELLOW,
+            )
+            self.submit_order(order, position_id=position.id)
+
+    def _make_qty(self) -> Quantity:
+        return self.instrument.make_qty(self.config.trade_size)
+
+
+def get_trading_strategy(
+    instrument_id: InstrumentId,
+    trade_size: Decimal = Decimal("1"),
+    entry_threshold: float = 0.5,
+    exec_algorithm_id: str | None = "MY_GENERIC_ALGO",
+) -> OracleStrategy:
+    """Build an OracleStrategy for the given instrument."""
+    config = OracleStrategyConfig(
+        instrument_id=instrument_id,
+        trade_size=trade_size,
+        entry_threshold=entry_threshold,
+        exec_algorithm_id=ExecAlgorithmId(exec_algorithm_id) if exec_algorithm_id else None,
+    )
+    return OracleStrategy(config=config)

--- a/strategies/databento_oracle_strategy/preprocessing.py
+++ b/strategies/databento_oracle_strategy/preprocessing.py
@@ -1,0 +1,85 @@
+"""Offline preprocessing: turn a sorted tick stream into pre-shifted oracle signals.
+
+For each TradeTick at time T we emit an ``OracleSignal`` *also stamped at T* but
+carrying the price observed at T + horizon (plus optional Gaussian noise). The
+two-pointer sweep keeps this O(N), which matters at full-day CME tick volumes.
+
+This runs on the same ``ticks`` list that ``backtest_engine.data_loader`` pulls
+from S3 — there is no separate data path, no live-stream lookahead, and the
+output is deterministic given a seed so runs are reproducible.
+"""
+from __future__ import annotations
+
+import random
+
+from nautilus_trader.model.data import TradeTick
+
+from strategies.databento_oracle_strategy.oracle_signal import OracleSignal
+
+
+def build_oracle_signals(
+    ticks: list,
+    horizon_seconds: float,
+    sigma: float = 0.0,
+    seed: int = 42,
+    signal_interval_seconds: float = 0.0,
+) -> list[OracleSignal]:
+    """Generate one OracleSignal per qualifying TradeTick.
+
+    Parameters
+    ----------
+    ticks : list
+        Mixed Nautilus data (e.g. trade + quote ticks) returned by the loader.
+        Non-``TradeTick`` items are ignored. Must be sorted by ``ts_event``.
+    horizon_seconds : float
+        How far in the future to look for the "oracle" price.
+    sigma : float
+        Stdev of additive Gaussian noise applied to the future price, in price
+        units. Use 0 for a perfect oracle; raise it to degrade signal quality.
+    seed : int
+        Seed for the noise RNG so backtests are reproducible.
+    signal_interval_seconds : float
+        Minimum gap between successive emitted signals. ``0`` means emit one
+        per tick. Useful for taming signal volume on dense streams.
+    """
+    if horizon_seconds <= 0:
+        raise ValueError(f"horizon_seconds must be positive, got {horizon_seconds}")
+
+    horizon_ns = int(horizon_seconds * 1_000_000_000)
+    interval_ns = int(signal_interval_seconds * 1_000_000_000)
+    rng = random.Random(seed)
+
+    trades: list[TradeTick] = [t for t in ticks if isinstance(t, TradeTick)]
+    if not trades:
+        return []
+
+    signals: list[OracleSignal] = []
+    j = 0
+    last_emit_ns = -interval_ns  # ensures the first tick passes the gap check
+
+    for current in trades:
+        if interval_ns and current.ts_event - last_emit_ns < interval_ns:
+            continue
+
+        target_ts = current.ts_event + horizon_ns
+        while j < len(trades) and trades[j].ts_event < target_ts:
+            j += 1
+        if j >= len(trades):
+            break
+
+        future_price = float(trades[j].price)
+        if sigma > 0.0:
+            future_price += rng.gauss(0.0, sigma)
+
+        signals.append(
+            OracleSignal(
+                instrument_id=current.instrument_id,
+                current_price=float(current.price),
+                future_price=future_price,
+                ts_event=current.ts_event,
+                ts_init=current.ts_init,
+            )
+        )
+        last_emit_ns = current.ts_event
+
+    return signals


### PR DESCRIPTION
- Adds `strategies/databento_oracle_strategy` — a research harness that trades a noisy oracle of the future price. Comprises `OracleSignal` (custom `Data`), `OracleStrategy` / `OracleStrategyConfig`, and `preprocessing.build_oracle_signals` which sweeps the tick stream in O(N) to emit pre-shifted signals.
- Wires the oracle flow into `backtest_engine.backtest_low_level`: builds signals from the loaded ticks, wraps each as `CustomData(DataType(OracleSignal), payload)` (raw subclass instances are dropped by the DataEngine as "unrecognized type"), injects them with `ClientId("ORACLE")`, and records the preprocessing options in run metadata so experiments are reproducible.
- Registers `"oracle"` in the strategy factory and switches `main.py` to invoke it with example parameters (30s horizon, sigma=0.1, 60s interval).

```
{
  "starting_balance": 1000000.0,
  "final_equity": 1000868.25,
  "total_return_pct": 0.086825,
  "realized_pnl": 868.25,
  "max_drawdown_pct": -0.0004998586649624819,
  "sharpe_ratio": 183.30404427930517,
  "trade_count": 382,
  "winners": 310,
  "losers": 57,
  "win_rate": 0.8115183246073299,
  "long_count": 191,
  "short_count": 191,
  "order_count": 764,
  "fill_count": 764,
  "total_commissions": 0.0,
  "mean_slippage": 0.0,
  "max_abs_slippage": 0.0
}
```