### PR TITLE
Fix claude commits

### DIFF
--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -68,8 +68,16 @@ The user prompt may be:
    from the transcript after you stop — do **not** try to compute them
    yourself.
 6. **On PASS**: snapshot per the `snapshot` skill. On CLOSE or FAIL: do not snapshot.
-7. **Commit**: `git add execution_algos/<algo-id>/ research/program_database.json`
-   then `git commit -m "<algo-id>: <status>, key scores"`.
+7. **Commit on a fresh iteration branch** (one branch per invocation, so the
+   base branch stays clean):
+   ```bash
+   git checkout -b iter/<algo-id>-$(date -u +%Y%m%dT%H%M%SZ)
+   git add execution_algos/<algo-id>/ research/program_database.json
+   git commit -m "<algo-id>: <status>, key scores"
+   ```
+   The branch forks from whichever branch was checked out when you were
+   invoked. Stay on the iter branch when you exit — the `SubagentStop` hook
+   will append its metadata-backfill commit to the same branch.
 8. **Final message**: brief prose summary — status, algo_id, key scores,
    trade count, and (if PASS) a suggestion for what a future iteration
    might try next.
@@ -95,7 +103,7 @@ The user prompt may be:
   just-appended entry, which is backfilled by the `SubagentStop` hook —
   not by you.
 - **Do not push branches other than `snapshots/<id>`.** Working commits
-  stay local on the current branch.
+  stay local on the per-iteration `iter/<algo-id>-<timestamp>` branch.
 
 ## Common pitfalls to avoid
 

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -77,7 +77,8 @@ The user prompt may be:
    ```
    The branch forks from whichever branch was checked out when you were
    invoked. Stay on the iter branch when you exit — the `SubagentStop` hook
-   will append its metadata-backfill commit to the same branch.
+   will append its metadata-backfill commit to the same branch and then
+   push the branch to `origin` (best-effort, all statuses).
 8. **Final message**: brief prose summary — status, algo_id, key scores,
    trade count, and (if PASS) a suggestion for what a future iteration
    might try next.
@@ -102,8 +103,10 @@ The user prompt may be:
   rewrite or delete entries. The one exception is the `meta` block of the
   just-appended entry, which is backfilled by the `SubagentStop` hook —
   not by you.
-- **Do not push branches other than `snapshots/<id>`.** Working commits
-  stay local on the per-iteration `iter/<algo-id>-<timestamp>` branch.
+- **Do not push branches manually.** The `SubagentStop` hook pushes the
+  per-iteration `iter/<algo-id>-<timestamp>` branch to `origin` after
+  backfilling metadata, and the `snapshot` skill pushes `snapshots/<id>`
+  on PASS. You should not invoke `git push` yourself.
 
 ## Common pitfalls to avoid
 

--- a/.claude/hooks/patch_program_db_tokens.py
+++ b/.claude/hooks/patch_program_db_tokens.py
@@ -16,9 +16,11 @@ Computes:
     carries a `usage` block in the transcript.
 
 After patching, attempts a `chore(<algo-id>): backfill execution metadata`
-commit so the working tree stays clean. Best-effort: if the commit fails
-(pre-commit hook, dirty unrelated files, no git, etc.) the file is left
-modified for the next iteration's commit to pick up.
+commit so the working tree stays clean, then attempts
+`git push --set-upstream origin <branch>` if the current branch is an
+`iter/*` branch. Both steps are best-effort: a failure (pre-commit hook,
+dirty unrelated files, no git, no remote, no auth, etc.) is silently
+ignored — the local commit stays in place and the user can push manually.
 """
 from __future__ import annotations
 
@@ -113,6 +115,28 @@ def _try_commit(cwd: str, algo_id: str) -> None:
         return  # Best-effort: leave file dirty for next iteration
 
 
+def _try_push(cwd: str) -> None:
+    """Best-effort: push the current branch to origin if it looks like a
+    researcher iter branch. Silently no-op on any failure (no auth, no
+    remote, detached HEAD, etc.). The user can always push manually."""
+    try:
+        branch = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if not branch.startswith("iter/"):
+            return  # Only push researcher iter branches from this hook.
+        subprocess.run(
+            ["git", "-C", cwd, "push", "--set-upstream", "origin", branch],
+            check=True,
+            capture_output=True,
+        )
+    except (subprocess.CalledProcessError, OSError, FileNotFoundError):
+        return  # Best-effort: leave unpushed; remote can be updated manually.
+
+
 def main() -> None:
     try:
         payload = json.load(sys.stdin)
@@ -161,6 +185,7 @@ def main() -> None:
 
     algo_id = str(last.get("id") or "unknown")
     _try_commit(cwd, algo_id)
+    _try_push(cwd)
 
 
 if __name__ == "__main__":

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,6 @@
       "Bash(ls ./strategies*)",
       "Bash(find . -path ./strategies -prune)",
       "Bash(cat strategies/*)"
-    ],
+    ]
   }
 }

--- a/.claude/skills/snapshot/SKILL.md
+++ b/.claude/skills/snapshot/SKILL.md
@@ -107,17 +107,26 @@ Report raw numbers — see `OBJECTIVE.md §8` honesty rules.
 
 ## 4. Snapshot procedure (automatic, recommended)
 
+By the time you reach this skill, the iteration commit has already been
+made on the `iter/<algo-id>-<timestamp>` branch (researcher agent §5
+step 8). The snapshot is a re-pointed branch off that commit.
+
 ```bash
-# Branch
+# Fork the snapshot branch from the current (iter) branch — the algorithm
+# code and program DB append are already committed here.
 git checkout -b snapshots/<algo-id>
 
-# Stage everything for the algorithm + the program DB append
-git add execution_algos/<algo-id>/ research/program_database.json
-
-# Commit message: "<algo-id>: pnl=+X.X% vs baseline, sharpe=X.XX"
-git commit -m "twap-volatility-aware: pnl=+14.2% vs simple, sharpe=1.42"
-
 # Push — GitHub Actions auto-uploads to S3 on snapshots/* branches
+git push origin snapshots/<algo-id>
+```
+
+If you arrive at this skill on a branch where the iteration commit has
+*not* yet been made (e.g., manual snapshotting), stage and commit first:
+
+```bash
+git checkout -b snapshots/<algo-id>
+git add execution_algos/<algo-id>/ research/program_database.json
+git commit -m "<algo-id>: pnl=+X.X% vs baseline, sharpe=X.XX"
 git push origin snapshots/<algo-id>
 ```
 

--- a/docs/OBJECTIVE.md
+++ b/docs/OBJECTIVE.md
@@ -46,7 +46,7 @@ until a passing algorithm is found or the iteration budget in
 3. IMPLEMENT execution_algos/<algo-id>/execution_algorithm.py + register in factory
 4. BACKTEST your algo AND the baseline on **train** dates only (one run_backtest per date per algo). Test is held out for Lambda.
 5. COMPARE metrics.json deltas against pass_gate → PASS / CLOSE / FAIL (decision is train-only)
-6. APPEND entry to research/program_database.json + git commit
+6. APPEND entry to research/program_database.json + git commit on a fresh `iter/<algo-id>-<timestamp>` branch
 7. On PASS: git push origin snapshots/<algo-id> — this triggers the Lambda evaluator on test
 8. POST-SNAPSHOT (in a follow-up invocation): retrieve the Lambda OOS report and merge into backtest-results.json (the `evaluate` skill)
 ```
@@ -211,9 +211,13 @@ not loop internally. The human (or a future orchestrator) is the loop driver.
    FAIL  — does not meet gate                     → log reason
 
 8. LOG to research/program_database.json (every attempt — pass, close, or fail)
-   Append the entry, then commit it together with the algorithm code:
+   Append the entry, then commit it together with the algorithm code on a
+   fresh per-iteration branch (so the base branch stays clean):
+     git checkout -b iter/<algo-id>-$(date -u +%Y%m%dT%H%M%SZ)
      git add execution_algos/<algo-id>/ research/program_database.json
      git commit -m "<algo-id>: <status>, +X.X% pnl vs baseline"
+   Stay on the iter branch when the invocation ends — the `SubagentStop`
+   metadata-backfill commit will land on the same branch.
    Failed entries prevent re-exploring dead ends.
 ```
 

--- a/docs/OBJECTIVE.md
+++ b/docs/OBJECTIVE.md
@@ -46,7 +46,7 @@ until a passing algorithm is found or the iteration budget in
 3. IMPLEMENT execution_algos/<algo-id>/execution_algorithm.py + register in factory
 4. BACKTEST your algo AND the baseline on **train** dates only (one run_backtest per date per algo). Test is held out for Lambda.
 5. COMPARE metrics.json deltas against pass_gate → PASS / CLOSE / FAIL (decision is train-only)
-6. APPEND entry to research/program_database.json + git commit on a fresh `iter/<algo-id>-<timestamp>` branch
+6. APPEND entry to research/program_database.json + git commit on a fresh `iter/<algo-id>-<timestamp>` branch (the SubagentStop hook backfills `meta` and pushes the branch to `origin`)
 7. On PASS: git push origin snapshots/<algo-id> — this triggers the Lambda evaluator on test
 8. POST-SNAPSHOT (in a follow-up invocation): retrieve the Lambda OOS report and merge into backtest-results.json (the `evaluate` skill)
 ```
@@ -217,7 +217,8 @@ not loop internally. The human (or a future orchestrator) is the loop driver.
      git add execution_algos/<algo-id>/ research/program_database.json
      git commit -m "<algo-id>: <status>, +X.X% pnl vs baseline"
    Stay on the iter branch when the invocation ends — the `SubagentStop`
-   metadata-backfill commit will land on the same branch.
+   hook will land its metadata-backfill commit on the same branch and then
+   push it to `origin` (best-effort; all statuses).
    Failed entries prevent re-exploring dead ends.
 ```
 


### PR DESCRIPTION
Each run of the researcher agent will create its own branch.

Issue to fix in the future, when we are running multiple back to back / parallel loops:
research/program_database.json is read from whichever branch is checked out at invocation time. If you stay on the iter branch between runs, subsequent runs fork off it and chains form. If you `git checkout <base>` between runs, each iter branch forks cleanly off the base, but the program DB on the base never grows — meaning later iterations won't see prior attempts unless iter branches are periodically merged or cherry-picked back. Pick a convention before running back-to-back.