### PR TITLE
Restore simple_execution_strategy module

### DIFF
--- a/execution_algos/simple_execution_strategy/__init__.py
+++ b/execution_algos/simple_execution_strategy/__init__.py
@@ -1,0 +1,3 @@
+from .execution_algorithm import get_execution_algorithm
+
+__all__ = ["get_execution_algorithm"]

--- a/execution_algos/simple_execution_strategy/execution_algorithm.py
+++ b/execution_algos/simple_execution_strategy/execution_algorithm.py
@@ -1,0 +1,39 @@
+from nautilus_trader.execution.algorithm import ExecAlgorithm
+from nautilus_trader.execution.config import ExecAlgorithmConfig
+from nautilus_trader.model.identifiers import ExecAlgorithmId
+
+
+class SimpleExecutionAlgorithmConfig(ExecAlgorithmConfig):
+    pass
+
+
+class SimpleExecutionAlgorithm(ExecAlgorithm):
+    """
+    A custom execution algorithm that demonstrates simple order handling.
+    It immediately executes the incoming order in full.
+    """
+
+    def on_start(self) -> None:
+        self.log.info("SimpleExecutionAlgorithm started.")
+
+    def on_reset(self) -> None:
+        pass
+
+    def on_order(self, order) -> None:
+        """
+        Intercepts incoming orders from strategies.
+        """
+        self.log.info(
+            f"SimpleExecutionAlgorithm handling order: {order.client_order_id} for {order.quantity}"
+        )
+
+        # Pass the order directly to the venue backend.
+        self.submit_order(order)
+
+
+def get_execution_algorithm(exec_id: str = "MY_GENERIC_ALGO"):
+    """
+    Instantiate and return the custom execution algorithm.
+    """
+    config = SimpleExecutionAlgorithmConfig(exec_algorithm_id=ExecAlgorithmId(exec_id))
+    return SimpleExecutionAlgorithm(config=config)


### PR DESCRIPTION
Files were inadvertently removed in acff558; the "simple" entry in execution_algos/__init__.py still references this module.