### PR TITLE
increase sigma to 3.0

### DIFF
--- a/research/config.yaml
+++ b/research/config.yaml
@@ -25,7 +25,7 @@ strategy:
   # run_backtest() when absent.
   kwargs:
     horizon_seconds:        30.0   # forecast window for the oracle signal
-    sigma:                   0.5   # noise added to the forecast (0 = perfect oracle)
+    sigma:                   3.0   # noise added to the forecast (0 = perfect oracle)
     seed:                    42    # RNG seed (reproducibility when sigma > 0)
     signal_interval_seconds: 1.0   # cadence of generated signals
 


### PR DESCRIPTION
Got better results from research loop after increasing sigma to 3.0, but still not enough to beat +5%

```
⏺ Iteration complete. spread-relative-skip landed at CLOSE — +3.98% P&L vs baseline (gate is +5%), with improvements to win rate, Sharpe, and drawdown.               
                                                                                                                                                                      
  Notable side-effect: this iteration restored the simple_execution_strategy module that was deleted in 95e3e20, so future iterations can run paired baseline         
  comparisons again. Prior iterations (imbalance-skip, momentum-skip, signal-consensus) ran at sigma=0.5 vs current sigma=3.0 — their numbers are not comparable.     
                                                                                                                                                                      
  Suggested follow-up: lower spread_multiplier from 1.5 → 1.2 for more aggressive filtering, or combine the spread filter with a directional momentum check.          
                                                                                                                                                                      
✻ Churned for 11m 30s  
```