### PR TITLE
Inline metadata generation in workflow; remove external script

### DIFF
--- a/.github/workflows/snapshot-execution-algo.yml
+++ b/.github/workflows/snapshot-execution-algo.yml
@@ -1,6 +1,9 @@
 name: Create Execution Algorithm Snapshot
 
 on:
+  push:
+    branches:
+      - 'snapshots/**'
   workflow_dispatch:
     inputs:
       algo_name:
@@ -11,9 +14,6 @@ on:
         description: 'Path to algorithm files'
         required: true
         type: string
-  push:
-    branches:
-      - 'snapshots/**'
 
 permissions:
   contents: read
@@ -83,19 +83,19 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           echo "Writing metadata.json into $ROOT"
-          cat > "$ROOT/metadata.json" <<'EOF'
-{
-  "algo_name": "${ALGO_NAME}",
-  "timestamp": "${TIMESTAMP}",
-  "commit_short": "${COMMIT_SHA}",
-  "commit_full": "${COMMIT_SHA_FULL}",
-  "branch": "${BRANCH}",
-  "repository": "${REPOSITORY}",
-  "triggered_by": "${TRIGGERED_BY}",
-  "actor": "${ACTOR}",
-  "run_id": "${RUN_ID}"
-}
-EOF
+          mkdir -p "$ROOT"
+          printf '%s\n' "{" \
+            "  \"algo_name\": \"${ALGO_NAME}\"," \
+            "  \"timestamp\": \"${TIMESTAMP}\"," \
+            "  \"commit_short\": \"${COMMIT_SHA}\"," \
+            "  \"commit_full\": \"${COMMIT_SHA_FULL}\"," \
+            "  \"branch\": \"${BRANCH}\"," \
+            "  \"repository\": \"${REPOSITORY}\"," \
+            "  \"triggered_by\": \"${TRIGGERED_BY}\"," \
+            "  \"actor\": \"${ACTOR}\"," \
+            "  \"run_id\": \"${RUN_ID}\"" \
+            "}" > "$ROOT/metadata.json"
+          echo "Wrote $ROOT/metadata.json"
       
       - name: Display snapshot
         run: |


### PR DESCRIPTION
This PR inlines metadata.json generation into the workflow and removes the external scripts/generate_metadata.py helper.

Changes:
- Write metadata.json directly from the workflow (safe printf) to avoid heredoc issues.
- Restrict push triggers to snapshots/** and keep manual workflow_dispatch.

This is ready for CI verification; a test snapshots/* branch will be pushed to run the workflow from this branch.