### PR TITLE
Add skip-outcome attribution for execution algorithms (closes #66)

### DIFF
--- a/.claude/skills/backtest/SKILL.md
+++ b/.claude/skills/backtest/SKILL.md
@@ -120,11 +120,52 @@ execution_algos/<algo-id>/results/
 ├── metadata.json                               # committed — reproduction record (runs[]); written by write_metadata()
 └── <YYYYMMDD>/                                 # per-run dir (one per trading date, auto-created by run_backtest() → persist())
     ├── metrics.json                             # committed — summary stats; see metrics-schema.md
+    ├── skipped_attribution.json                 # committed — per-skip counterfactual P&L summary (issue #66)
     ├── account.csv                              # gitignored — equity curve
     ├── orders.csv                               # gitignored — order log (with commissions, slippage)
     ├── fills.csv                                # gitignored — fill log
-    └── positions.csv                            # gitignored — position log (entry, realized_pnl, etc.)
+    ├── positions.csv                            # gitignored — position log (entry, realized_pnl, etc.)
+    └── skips.csv                                # gitignored — per-skip detail (only when the algo skipped anything)
 ```
+
+### Skip attribution (`skipped_attribution.json`)
+
+When an execution algorithm declines to submit an OPEN order, the
+harness records the would-be counterfactual fill at top-of-book and
+looks the mid up at `ts_event + horizon_seconds` (default 30s, matching
+the oracle strategy's signal lifetime). The resulting per-skip would-be
+P&L is bucketed into `negative` / `near_zero` / `positive`:
+
+```json
+{
+  "date": "2026-03-08",
+  "skipped_count": 12430,
+  "attributed_count": 12100,
+  "would_be_pnl_distribution": {"negative": 4100, "near_zero": 5200, "positive": 2800},
+  "would_be_pnl_total": -1830.5,
+  "precision": 0.339,
+  "recall": null,
+  "horizon_seconds": 30.0
+}
+```
+
+`precision = negative_count / attributed_count` answers the
+researcher's central question: is the filter precisely rejecting
+losers, or just removing volume? A high-precision filter (≫ 0.5)
+discriminates; a flat distribution (≈ 1/3 in each bucket) just trims
+volume. Algorithms that never skip emit an empty record (counts all
+zero) — the baseline run keeps the artifact set uniform.
+
+Wire-up for new skip-aware algorithms:
+1. Add `skip_recorder=None` to the `get_execution_algorithm` signature
+   and pass it through to the algo constructor.
+2. At every skip site call
+   `self._skip_recorder.record(ts_event=..., instrument_id=..., parent_order_id=..., side=..., quantity=..., bid=..., ask=..., trigger=...)`.
+
+The harness instantiates one `SkipRecorder` per `run_backtest()` call
+and injects it via `execution_algorithm_kwargs`. Algorithms that never
+skip can ignore the kwarg (see `simple_execution_strategy` for the
+no-op pattern).
 
 Committed files: `backtest-results.json`, `metadata.json`, and each
 `<run>/metrics.json`. Everything else is gitignored.

--- a/.claude/skills/backtest/metrics-schema.md
+++ b/.claude/skills/backtest/metrics-schema.md
@@ -15,3 +15,5 @@ Produced by `compute_metrics()` in `backtest_engine/results.py:153`.
 | `order_count`, `fill_count` | order/fill counts |
 | `total_commissions` | sum across orders (account currency) |
 | `mean_slippage`, `max_abs_slippage` | execution-quality proxy (price units; multiply by contract multiplier for $) |
+| `skipped_count` | number of OPEN orders the execution algorithm declined to submit (issue #66; 0 for algorithms that never skip) |
+| `skip_precision` | fraction of attributed skips whose counterfactual P&L was negative (the filter "correctly" rejected a loser); `null` when no skips were attributed |

--- a/backtest_engine/backtest_low_level.py
+++ b/backtest_engine/backtest_low_level.py
@@ -17,6 +17,11 @@ from nautilus_trader.model.identifiers import ClientId
 from backtest_engine.arrival_price import attach_implementation_shortfall
 from backtest_engine.data_loader import load_dbn_partition
 from backtest_engine.results import Reports, compute_metrics, persist
+from backtest_engine.skip_attribution import (
+    DEFAULT_HORIZON_SECONDS,
+    SkipRecorder,
+    attach_skip_attribution,
+)
 from execution_algos import create_execution_algorithm
 from strategies import create_strategy
 from strategies.databento_oracle_strategy import OracleSignal, build_oracle_signals
@@ -105,6 +110,12 @@ def run_backtest(
     if execution_algorithm_name == "simple":
         execution_options.setdefault("exec_id", "MY_GENERIC_ALGO")
 
+    # Every algorithm gets a SkipRecorder, even ones that never skip — the
+    # baseline run will simply produce an empty skipped_attribution.json,
+    # which keeps the per-run artifact set uniform across algorithms.
+    skip_recorder = SkipRecorder()
+    execution_options.setdefault("skip_recorder", skip_recorder)
+
     strategy = create_strategy(strategy_name, **strategy_options)
     engine.add_strategy(strategy=strategy)
 
@@ -126,10 +137,26 @@ def run_backtest(
         positions=engine.trader.generate_positions_report(),
     )
 
+    # The skip-attribution counterfactual measures P&L over the strategy's
+    # natural signal lifetime. For the oracle strategy that's
+    # `horizon_seconds` from strategy_kwargs; everything else falls back
+    # to the module default (currently matches the oracle default).
+    skip_horizon = float(
+        (oracle_options or {}).get("horizon_seconds", DEFAULT_HORIZON_SECONDS)
+    )
+    skips_df, skip_summary = attach_skip_attribution(
+        skip_recorder,
+        ticks,
+        horizon_seconds=skip_horizon,
+        multiplier=float(instrument.multiplier),
+    )
+
     metrics = {
         **compute_metrics(reports, starting_balance=STARTING_BALANCE_USD),
         **is_metrics,
         "unrealized_pnl": _unrealized_pnl(reports.positions, ticks, instrument),
+        "skipped_count": skip_summary["skipped_count"],
+        "skip_precision": skip_summary["precision"],
     }
 
     execution_dir_name = EXECUTION_DIRS.get(execution_algorithm_name, execution_algorithm_name)
@@ -138,6 +165,8 @@ def run_backtest(
         date=date,
         metrics=metrics,
         reports=reports,
+        skip_attribution=skip_summary,
+        skips=skips_df,
     )
     print(f"Run artifact: {run_dir}")
 

--- a/backtest_engine/results.py
+++ b/backtest_engine/results.py
@@ -193,8 +193,15 @@ def persist(
     date: str,
     metrics: dict[str, Any],
     reports: Reports,
+    skip_attribution: dict[str, Any] | None = None,
+    skips: pd.DataFrame | None = None,
 ) -> Path:
-    """Write a run to `{strategy_dir}/results/{date}/` and return that path."""
+    """Write a run to `{strategy_dir}/results/{date}/` and return that path.
+
+    When ``skip_attribution`` is supplied the per-date summary is written
+    to ``skipped_attribution.json`` (committed) and the per-skip detail
+    to ``skips.csv`` (gitignored, like the other raw report CSVs).
+    """
     if not date:
         raise ValueError("persist() requires a trading date")
     run_dir = strategy_dir / "results" / date
@@ -216,5 +223,12 @@ def persist(
     reports.orders.to_csv(run_dir / "orders.csv", index=False)
     reports.fills.to_csv(run_dir / "fills.csv", index=False)
     reports.positions.to_csv(run_dir / "positions.csv", index=False)
+
+    if skip_attribution is not None:
+        (run_dir / "skipped_attribution.json").write_text(
+            json.dumps({"date": date, **skip_attribution}, indent=2, default=str)
+        )
+    if skips is not None and not skips.empty:
+        skips.to_csv(run_dir / "skips.csv", index=False)
 
     return run_dir

--- a/backtest_engine/skip_attribution.py
+++ b/backtest_engine/skip_attribution.py
@@ -1,0 +1,229 @@
+"""Per-skip counterfactual P&L attribution.
+
+When an execution algorithm declines to submit an OPEN order, it can call
+``SkipRecorder.record(...)`` with the parent-order metadata and the
+top-of-book quote captured at the skip site. After ``engine.run()`` the
+backtest pipeline calls :func:`attach_skip_attribution`, which:
+
+  * Simulates the counterfactual entry fill at top-of-book (ask for BUY,
+    bid for SELL) at the skip's ``ts_event``.
+  * Looks up the mid ``horizon_seconds`` after the skip and uses that as
+    the would-be exit price. The horizon defaults to the oracle
+    strategy's signal lifetime so the counterfactual mirrors a single
+    strategy decision cycle.
+  * Computes per-skip would-be P&L in price units and bps, tags each by
+    direction (BUY/SELL) and magnitude bucket
+    (negative / near_zero / positive), and aggregates a per-date summary.
+
+The resulting ``skipped_attribution.json`` lets the researcher
+distinguish "we precisely skipped losers" (negative-bucket dominates)
+from "we just removed volume" (flat distribution across buckets).
+Reference: GitHub issue #66.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from backtest_engine.arrival_price import _build_quote_index, _lookup
+
+# Default counterfactual exit horizon, in seconds. Matches the oracle
+# strategy's default `horizon_seconds`, so a "would-be PnL" reflects one
+# full signal lifetime rather than a microstructure tick. Override via
+# `attach_skip_attribution(..., horizon_seconds=...)`.
+DEFAULT_HORIZON_SECONDS: float = 30.0
+
+# |would-be P&L| / arrival_mid below this threshold (in bps) is bucketed
+# as "near_zero". 1 bps on a $4500 MES future ≈ $0.45 per contract — well
+# inside one tick of price noise, so anything tighter is signal-free.
+NEAR_ZERO_BPS: float = 1.0
+
+
+@dataclass
+class SkipEvent:
+    """A single skip decision captured at the algorithm's skip site.
+
+    All prices are in the instrument's quote currency. ``ts_event`` is
+    nanoseconds since the Unix epoch (Nautilus convention).
+    """
+
+    ts_event: int
+    instrument_id: str
+    parent_order_id: str
+    side: str
+    quantity: float
+    bid: float
+    ask: float
+    trigger: str | None = None
+
+
+@dataclass
+class SkipRecorder:
+    """Append-only buffer of :class:`SkipEvent`. One per backtest run.
+
+    Construct it in the backtest harness, pass it into the execution
+    algorithm factory via ``skip_recorder=...``, and call
+    :func:`attach_skip_attribution` after ``engine.run()`` returns.
+    """
+
+    events: list[SkipEvent] = field(default_factory=list)
+
+    def record(
+        self,
+        *,
+        ts_event: int,
+        instrument_id: Any,
+        parent_order_id: Any,
+        side: str,
+        quantity: float,
+        bid: float,
+        ask: float,
+        trigger: str | None = None,
+    ) -> None:
+        self.events.append(
+            SkipEvent(
+                ts_event=int(ts_event),
+                instrument_id=str(instrument_id),
+                parent_order_id=str(parent_order_id),
+                side=str(side).upper(),
+                quantity=float(quantity),
+                bid=float(bid),
+                ask=float(ask),
+                trigger=str(trigger) if trigger is not None else None,
+            )
+        )
+
+    def to_frame(self) -> pd.DataFrame:
+        cols = [
+            "ts_event", "instrument_id", "parent_order_id",
+            "side", "quantity", "bid", "ask", "trigger",
+        ]
+        if not self.events:
+            return pd.DataFrame(columns=cols)
+        return pd.DataFrame([{c: getattr(e, c) for c in cols} for e in self.events])
+
+
+_EMPTY_SUMMARY: dict[str, Any] = {
+    "skipped_count": 0,
+    "attributed_count": 0,
+    "would_be_pnl_distribution": {"negative": 0, "near_zero": 0, "positive": 0},
+    "would_be_pnl_total": 0.0,
+    "precision": None,
+    "recall": None,
+    "horizon_seconds": None,
+}
+
+
+def _bucket_label(pnl_bps: float) -> str:
+    if math.isnan(pnl_bps):
+        return "unattributed"
+    if pnl_bps > NEAR_ZERO_BPS:
+        return "positive"
+    if pnl_bps < -NEAR_ZERO_BPS:
+        return "negative"
+    return "near_zero"
+
+
+def attach_skip_attribution(
+    recorder: SkipRecorder,
+    ticks: list,
+    *,
+    horizon_seconds: float = DEFAULT_HORIZON_SECONDS,
+    multiplier: float = 1.0,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """Compute counterfactual P&L for every skip event.
+
+    For each skip we look up two mids from the quote stream:
+      * ``entry_mid`` — mid at the skip ``ts_event`` (sanity check).
+      * ``exit_mid``  — mid at ``ts_event + horizon_seconds`` (the
+        counterfactual exit). When the horizon walks off the end of the
+        day's tick stream, the skip is reported with NaN P&L and is
+        excluded from the precision tally.
+
+    Sign convention: ``would_be_pnl > 0`` means the skipped trade would
+    have made money — i.e. the skip filter rejected a *winner*. Lots of
+    negative-bucket skips means the filter precisely targets losers;
+    a flat distribution means the filter just removes volume.
+    """
+    skips = recorder.to_frame()
+    if skips.empty:
+        return skips, {**_EMPTY_SUMMARY, "horizon_seconds": float(horizon_seconds)}
+
+    quote_index = _build_quote_index(ticks)
+    skips = skips.sort_values("ts_event").reset_index(drop=True)
+
+    skip_ts = skips["ts_event"].to_numpy(dtype=np.int64)
+    sides = skips["side"].to_numpy()
+    qty = skips["quantity"].to_numpy(dtype=np.float64)
+    direction = np.where(sides == "BUY", 1.0, np.where(sides == "SELL", -1.0, 0.0))
+
+    # Counterfactual entry: top-of-book on the same tick (ask for BUY,
+    # bid for SELL). This is what the skipped order would have filled at
+    # under the `top_of_book_only` execution constraint.
+    entry_fill = np.where(
+        sides == "BUY",
+        skips["ask"].to_numpy(dtype=np.float64),
+        skips["bid"].to_numpy(dtype=np.float64),
+    )
+
+    if quote_index is None:
+        entry_mid = np.full(len(skips), np.nan)
+        exit_mid = np.full(len(skips), np.nan)
+    else:
+        qts, qmid = quote_index
+        entry_mid = _lookup(skip_ts, qts, qmid)
+        horizon_ns = int(horizon_seconds * 1_000_000_000)
+        exit_target = skip_ts + horizon_ns
+        exit_mid = _lookup(exit_target, qts, qmid)
+        # _lookup returns the rightmost mid <= target. If the target
+        # walks past the last tick of the day, every skip past that
+        # point gets the same final mid, which is a degenerate
+        # extrapolation rather than a real counterfactual. Mask those.
+        last_ts = int(qts[-1])
+        exit_mid = np.where(exit_target > last_ts, np.nan, exit_mid)
+
+    would_be_pnl = (exit_mid - entry_fill) * direction * qty * float(multiplier)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        pnl_bps = np.where(
+            entry_mid > 0,
+            (exit_mid - entry_fill) * direction / entry_mid * 10_000.0,
+            np.nan,
+        )
+
+    skips["entry_mid"] = entry_mid
+    skips["entry_fill"] = entry_fill
+    skips["exit_mid"] = exit_mid
+    skips["would_be_pnl"] = would_be_pnl
+    skips["would_be_pnl_bps"] = pnl_bps
+    skips["bucket"] = [_bucket_label(x) for x in pnl_bps]
+
+    attributed = skips["bucket"] != "unattributed"
+    buckets = {
+        "negative":  int(((skips["bucket"] == "negative") & attributed).sum()),
+        "near_zero": int(((skips["bucket"] == "near_zero") & attributed).sum()),
+        "positive":  int(((skips["bucket"] == "positive") & attributed).sum()),
+    }
+    attributed_count = int(attributed.sum())
+    precision = (buckets["negative"] / attributed_count) if attributed_count > 0 else None
+    pnl_total = float(np.nansum(would_be_pnl))
+
+    summary = {
+        "skipped_count": int(len(skips)),
+        "attributed_count": attributed_count,
+        "would_be_pnl_distribution": buckets,
+        "would_be_pnl_total": pnl_total,
+        # Fraction of attributed skips that the filter correctly rejected
+        # (would have been losers). `recall` requires a comparable
+        # denominator over the actual losers in the un-skipped trades and
+        # is left None for now — adding it requires pairing skip events
+        # with the trade-level realized P&L distribution, which is a
+        # separate piece of infrastructure (see issue #66 schema).
+        "precision": float(precision) if precision is not None else None,
+        "recall": None,
+        "horizon_seconds": float(horizon_seconds),
+    }
+    return skips, summary

--- a/execution_algos/simple_execution_strategy/execution_algorithm.py
+++ b/execution_algos/simple_execution_strategy/execution_algorithm.py
@@ -31,9 +31,14 @@ class SimpleExecutionAlgorithm(ExecAlgorithm):
         self.submit_order(order)
 
 
-def get_execution_algorithm(exec_id: str = "MY_GENERIC_ALGO"):
+def get_execution_algorithm(exec_id: str = "MY_GENERIC_ALGO", skip_recorder=None):
     """
     Instantiate and return the custom execution algorithm.
+
+    ``skip_recorder`` is accepted for interface uniformity with skip-aware
+    algorithms (issue #66). The simple algorithm never skips, so the
+    recorder stays empty.
     """
+    del skip_recorder
     config = SimpleExecutionAlgorithmConfig(exec_algorithm_id=ExecAlgorithmId(exec_id))
     return SimpleExecutionAlgorithm(config=config)

--- a/execution_algos/streak-spread-tight/execution_algorithm.py
+++ b/execution_algos/streak-spread-tight/execution_algorithm.py
@@ -77,7 +77,7 @@ class StreakSpreadTightAlgorithm(ExecAlgorithm):
     No order quantity is ever modified. Quantity invariant always preserved.
     """
 
-    def __init__(self, config: StreakSpreadTightConfig) -> None:
+    def __init__(self, config: StreakSpreadTightConfig, skip_recorder=None) -> None:
         super().__init__(config=config)
         self._spread_multiplier: float = config.spread_multiplier
         self._spread_window: int = config.spread_window
@@ -99,6 +99,10 @@ class StreakSpreadTightAlgorithm(ExecAlgorithm):
 
         # Subscription tracking
         self._subscribed: set[str] = set()
+
+        # Per-run skip recorder (issue #66). May be None when the
+        # algorithm is constructed outside the research harness.
+        self._skip_recorder = skip_recorder
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -276,6 +280,7 @@ class StreakSpreadTightAlgorithm(ExecAlgorithm):
                 f"SKIP order {order.client_order_id} "
                 f"(trigger={trigger_label}) — adverse regime."
             )
+            self._record_skip(order, quote, trigger_label)
             self._position_flat = True
             # Do NOT call submit_order — quantity invariant preserved
         else:
@@ -298,6 +303,33 @@ class StreakSpreadTightAlgorithm(ExecAlgorithm):
         self._position_flat = False
         self.submit_order(order)
 
+    def _record_skip(self, order, quote, trigger: str) -> None:
+        """Log a skip event to the per-run SkipRecorder (issue #66).
+
+        Captures top-of-book at decision time so the post-run attribution
+        can simulate the counterfactual fill. Silently no-ops when no
+        recorder is attached (e.g. tests instantiating the algorithm
+        directly) or when the cached quote is missing.
+        """
+        if self._skip_recorder is None or quote is None:
+            return
+        try:
+            bid = float(str(quote.bid_price))
+            ask = float(str(quote.ask_price))
+            ts_event = int(getattr(quote, "ts_event", 0)) or int(order.ts_init)
+            self._skip_recorder.record(
+                ts_event=ts_event,
+                instrument_id=order.instrument_id,
+                parent_order_id=order.client_order_id,
+                side="BUY" if order.side == OrderSide.BUY else "SELL",
+                quantity=float(str(order.quantity)),
+                bid=bid,
+                ask=ask,
+                trigger=trigger,
+            )
+        except Exception as exc:  # noqa: BLE001 — attribution must never break the run
+            self.log.warning(f"skip-recorder failed: {exc}")
+
 
 def get_execution_algorithm(
     exec_id: str = "MY_GENERIC_ALGO",
@@ -305,6 +337,7 @@ def get_execution_algorithm(
     spread_window: int = 60,
     min_spread_window: int = 10,
     streak_lookback: int = 2,
+    skip_recorder=None,
 ) -> StreakSpreadTightAlgorithm:
     """Instantiate and return the StreakSpreadTightAlgorithm.
 
@@ -321,6 +354,11 @@ def get_execution_algorithm(
         Minimum samples before spread logic activates. Default 10.
     streak_lookback : int
         Number of consecutive losses to trigger streak skip. Default 2.
+    skip_recorder : SkipRecorder | None
+        Optional per-run buffer that records each skip decision for
+        counterfactual P&L attribution (issue #66). Injected by the
+        research harness; absent when the algorithm is wired up
+        manually.
     """
     config = StreakSpreadTightConfig(
         exec_algorithm_id=ExecAlgorithmId(exec_id),
@@ -329,4 +367,4 @@ def get_execution_algorithm(
         min_spread_window=min_spread_window,
         streak_lookback=streak_lookback,
     )
-    return StreakSpreadTightAlgorithm(config=config)
+    return StreakSpreadTightAlgorithm(config=config, skip_recorder=skip_recorder)


### PR DESCRIPTION
## Summary
- Adds a `SkipRecorder` that the backtest harness instantiates per `run_backtest()` call and injects into each execution algorithm via `skip_recorder=...`. Algorithms call `record(...)` at every skip site.
- After `engine.run()`, `attach_skip_attribution()` simulates the counterfactual fill at top-of-book on the skip tick, looks up the mid `horizon_seconds` later (defaults to the oracle strategy's `horizon_seconds`, so the counterfactual reflects one strategy decision cycle), and buckets per-skip would-be P&L into `negative` / `near_zero` / `positive`. `precision = negative / attributed` answers issue #66's central question.
- Per-date summary written to `execution_algos/<algo>/results/<YYYYMMDD>/skipped_attribution.json` (committed), per-skip detail to `skips.csv` (gitignored, alongside the other raw report CSVs).
- `streak-spread-tight` is wired to call the recorder so the feature has a real exerciser. The `simple` baseline accepts the kwarg as a no-op so the artifact set stays uniform across algorithms.
- Skill docs (`.claude/skills/backtest/SKILL.md`, `metrics-schema.md`) updated with the new artifact and metric fields.

Schema produced (matches issue #66 with a couple of additions for honest reporting):

```json
{
  "date": "2026-03-08",
  "skipped_count": 12430,
  "attributed_count": 12100,
  "would_be_pnl_distribution": {"negative": 4100, "near_zero": 5200, "positive": 2800},
  "would_be_pnl_total": -1830.5,
  "precision": 0.339,
  "recall": null,
  "horizon_seconds": 30.0
}
```

`attributed_count` excludes skips whose horizon walks past the end of the day's tick stream (would otherwise be a degenerate extrapolation).

## Test plan
- [ ] Run `python scripts/run_research_backtest.py --algo streak-spread-tight` inside Docker and confirm:
  - Each `results/<YYYYMMDD>/` directory contains a populated `skipped_attribution.json`.
  - `skipped_count` is non-zero and matches `skips.csv` row count for that date.
  - `precision` reads plausibly (a working skip filter should be ≳ 0.4; pure volume removal sits near 0.33).
- [ ] Run `python scripts/run_research_backtest.py --baseline-only` and confirm each baseline run emits a `skipped_attribution.json` with all counts at 0 (the simple algorithm never skips, so the recorder stays empty).
- [ ] Hand-verify one skip in `skips.csv`: `entry_fill` should equal `ask` for BUY / `bid` for SELL at the recorded `ts_event`, and `would_be_pnl = (exit_mid - entry_fill) × direction × quantity × multiplier`.

## What I could not do here / would like your approval on
- **Couldn't run the backtest end-to-end in this environment.** No `nautilus_trader` / `numpy` are installed outside the Docker image, so I have only static checks (`ast.parse` passes for every file I touched). Please run the test plan above inside Docker once before merging; flag anything unexpected and I'll iterate.
- **Did not touch the aggregator** (`scripts/run_research_backtest.py → aggregate()` / `write_backtest_results()`). The issue specifies a per-date artifact and that is what the PR delivers. I can fold `skipped_count` / `skip_precision` into the top-level `backtest-results.json` (probably as `sum` / `attributed-count-weighted-mean` respectively) in a follow-up if you want it surfaced at the aggregate level too — let me know.
- **`recall` is left `null`.** Per the issue schema, `recall` requires pairing skips with the actual losers in the un-skipped trades. That is a second piece of infrastructure (joining per-skip events against per-trade realized P&L) that I'd rather propose as a separate change once we see whether the precision number alone resolves the inference gap that motivated this issue.
- **`horizon_seconds` defaults to 30s** (oracle strategy's signal lifetime). If you would prefer a different default (e.g., a faster microstructure horizon for spread-based skips), say so and I'll switch the default — it's a one-line change at `DEFAULT_HORIZON_SECONDS` in `skip_attribution.py`.
- **No backfill of `skipped_attribution.json` for the existing committed `streak-spread-tight` per-date dirs.** Generating those requires re-running the backtest, which needs Docker. Future runs will produce them; let me know if you want the existing run dirs refreshed.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)