### PR TITLE
backtest: set Nautilus log level to WARNING

### DIFF
--- a/backtest_engine/backtest_low_level.py
+++ b/backtest_engine/backtest_low_level.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from nautilus_trader.backtest.config import BacktestEngineConfig
 from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.common.config import LoggingConfig
 from nautilus_trader.model import DataType
 from nautilus_trader.model import Money
 from nautilus_trader.model import TraderId
@@ -59,7 +60,10 @@ def run_backtest(
     """Run the low-level backtest, persist a comparable run artifact, and return the engine."""
     instrument, ticks = load_dbn_partition(date, symbol)
 
-    config = BacktestEngineConfig(trader_id=TraderId("BACKTESTER-001"))
+    config = BacktestEngineConfig(
+        trader_id=TraderId("BACKTESTER-001"),
+        logging=LoggingConfig(log_level="WARNING"),
+    )
     engine = BacktestEngine(config=config)
 
     glbx = Venue("GLBX")


### PR DESCRIPTION
## Summary
- Sets `LoggingConfig(log_level="WARNING")` on the `BacktestEngineConfig` in `backtest_engine/backtest_low_level.py`.
- Nautilus's default INFO logging emits one record per `OrderFilled` / `PositionClosed` / account-state update. The training-window runner (`scripts/run_research_backtest.py`) captures each backtest subprocess's stderr via `subprocess.run(capture_output=True)`, so on a busy trading day this stderr buffers ~10+ GB in the **runner's** memory over a 600s window — most of the `13.9 GB` parent-process RSS seen on recent failures was this log noise, not the backtest itself (the child peaks at ~7 GB).
- WARNING level keeps the load-bearing records (e.g. unhandled `Actor.on_stop` warnings) while dropping the per-event spam. With this change the per-date subprocess timeout in `scripts/run_research_backtest.py:75` can be safely raised without the runner approaching the 15 GB host limit.

## Test plan
- [ ] `python scripts/run_research_backtest.py --baseline-only --dates 20260308` completes and writes `metrics.json` for the date
- [ ] `python scripts/run_research_backtest.py --algo streak-spread-tight --dates 20260316 --use-cached-baseline` completes and matches the previous train-window metrics for that date
- [ ] Spot-check that genuine Nautilus warnings (e.g. `Actor.on_stop not overridden`) still appear in subprocess stderr on a failing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)