### PR TITLE
runner: cap per-backtest virtual memory via RLIMIT_AS (issue #61)

### DIFF
--- a/scripts/run_research_backtest.py
+++ b/scripts/run_research_backtest.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import resource
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -74,9 +75,52 @@ DEFAULT_SYMBOL = "MESM6"
 # limit. If you regularly bump this, something else is wrong.
 SUBPROCESS_TIMEOUT_SEC = 600
 
+# Per-backtest virtual-memory ceiling for the --internal-single-run child.
+# Nautilus holds all order/fill/position objects in engine.trader caches
+# until reports are generated at end; a busy day on a non-skip algo can
+# push RSS past 10 GB (~9.5 GB measured for the simple baseline on
+# 20260312). On a 16 GB / 0 swap host that's right at the OOM edge, and
+# the allocator stalls under pressure make the subprocess timeout look
+# like a hang. With this cap, the child raises MemoryError quickly
+# instead of thrashing the OS — turns the failure mode from "wedge for
+# minutes" into "fail in seconds." Override with RESEARCH_MEM_CAP_GB=0
+# to disable. Enforced via RLIMIT_AS — works on Linux (the agent-loop
+# host); macOS treats it as advisory and the setrlimit call may return
+# EINVAL, in which case we log a warning and continue uncapped.
+MEMORY_CAP_GB_DEFAULT = 12
+
 # Magic prefix on the child's stdout line carrying the result payload.
 # Anything goes after this prefix as long as it's a single line of JSON.
 METRICS_MARKER = "__METRICS_JSON__"
+
+
+def _apply_memory_cap() -> None:
+    """Set RLIMIT_AS for the current process to bound peak memory.
+
+    No-op when RESEARCH_MEM_CAP_GB=0 or when the platform refuses the
+    setrlimit call (e.g. unprivileged WSL). Failures are non-fatal — we
+    log a warning to stderr and continue; the original failure mode
+    (OS-level memory pressure) is no worse than not having the cap.
+    """
+    try:
+        cap_gb = float(os.environ.get("RESEARCH_MEM_CAP_GB", MEMORY_CAP_GB_DEFAULT))
+    except ValueError:
+        print(
+            f"WARN: RESEARCH_MEM_CAP_GB={os.environ.get('RESEARCH_MEM_CAP_GB')!r} "
+            f"is not a number; ignoring",
+            file=sys.stderr,
+        )
+        return
+    if cap_gb <= 0:
+        return
+    cap_bytes = int(cap_gb * 1024 * 1024 * 1024)
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (cap_bytes, cap_bytes))
+    except (ValueError, OSError) as exc:
+        print(
+            f"WARN: could not apply RLIMIT_AS={cap_gb} GB ({exc}); continuing without cap",
+            file=sys.stderr,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -561,6 +605,8 @@ def _do_internal_single_run(args: argparse.Namespace) -> int:
     On failure we exit non-zero; parent surfaces stderr tail. Do not print
     anything else to stdout after the marker line.
     """
+    _apply_memory_cap()
+
     if not args.algo:
         print("ERROR: --internal-single-run requires --algo", file=sys.stderr)
         return 2


### PR DESCRIPTION
## Summary
- Apply `RLIMIT_AS` at the start of the `--internal-single-run` child so a Nautilus engine that loads too much state raises `MemoryError` immediately instead of thrashing the OS.
- Default cap 12 GB, overridable via `RESEARCH_MEM_CAP_GB` env var; set to `0` to disable.

## Why
Investigating #61, I measured peak RSS for the `simple` baseline on 20260312 (2.2M ticks, 11k orders): **9.5 GB** (memory probe results in #61 comments). The 16 GB / 0 swap agent-loop host has no headroom left for the parent runner, the researcher subagent, or other concurrent work. A heavier no-skip algo (AND-logic skip filter that submits ~3× the orders) OOMs.

Without a cap, the kernel thrashes for many seconds under memory pressure, making the 600s subprocess timeout look like a hang and cascading per-date in the runner's date loop (#61's "hot pulling" behavior).

## Test plan
- [x] Linux verification (python:3.12-slim docker image): setrlimit succeeds at 4 GB; a 5 GB `bytearray` allocation raises `MemoryError` immediately as expected.
- [x] macOS verification: `RLIMIT_AS` returns EINVAL even when both soft/hard are `unlimited` (known platform quirk). Warning logged to stderr and child continues uncapped — safe fallback, same behavior as before this PR.
- [ ] Reviewer: confirm in the Linux agent-loop environment that a busy-day backtest fails with MemoryError (not OS thrash) when `RESEARCH_MEM_CAP_GB` is set below the measured peak.

## Related fixes
This addresses the most-leverage item in the #61 writeup. Three companion PRs will follow:
- skip non-trading weekend dates in the runner
- iteration wall-clock budget in `config.yaml`
- lower the per-date subprocess timeout (depends on this PR being merged first — the 600s ceiling exists primarily to absorb the memory-pressure tail this cap eliminates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)