### PR TITLE
runner: drop Saturdays from train_dates_from_config (issue #61)

### DIFF
--- a/scripts/run_research_backtest.py
+++ b/scripts/run_research_backtest.py
@@ -136,14 +136,23 @@ def load_config(path: Path) -> dict:
 
 
 def train_dates_from_config(cfg: dict) -> list[str]:
-    """Calendar-day YYYYMMDD list, both endpoints inclusive.
+    """Calendar-day YYYYMMDD list, both endpoints inclusive, weekends-aware.
 
-    Uses freq='D' not freq='B'. GLBX FX futures trade Sunday evening through
-    Friday US time, so Sunday partitions exist in the dataset. Missing dates
-    surface downstream as a run_backtest() failure, which we catch and skip.
+    GLBX FX futures trade Sunday evening through Friday US time, so:
+      - Saturday partitions don't exist → drop (dropping here saves a
+        wasted S3 sync attempt + a guaranteed failure entry in the
+        runner's per-date loop, which used to cost ~600s per Saturday
+        on cascade-fail).
+      - Sunday partitions DO exist (the evening session) → keep.
+    Other non-trading dates (US holidays) are not filtered here; they
+    still surface downstream as a run_backtest() failure, which we
+    catch and skip.
     """
     start, end = cfg["data_window"]["train"]
-    return pd.date_range(start, end, freq="D").strftime("%Y%m%d").tolist()
+    days = pd.date_range(start, end, freq="D")
+    # pandas dayofweek: Mon=0..Sun=6. Drop Saturday only.
+    days = days[days.dayofweek != 5]
+    return days.strftime("%Y%m%d").tolist()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Filter Saturdays out of the train date list returned by `train_dates_from_config()`.
- CME GLBX FX futures have no Saturday session, so Saturday partitions don't exist in the dataset.
- Sundays kept (GLBX evening session exists).

## Why
Investigating #61, the runner's per-date loop wastes work on Saturdays:

1. S3 sync attempt for a partition that doesn't exist.
2. Guaranteed FAIL entry in the per-date loop.
3. Worse: on cascade with the 600s subprocess timeout, each Saturday could burn ~600s before the runner moved on.

Current default train window `2026-03-08..2026-03-21` contains two Saturdays (`03-14`, `03-21`). Verified locally:

```
train window: ['2026-03-08', '2026-03-21']
dates returned: ['20260308', '20260309', '20260310', '20260311', '20260312',
                 '20260313', '20260315', '20260316', '20260317', '20260318',
                 '20260319', '20260320']
count: 12
```

03-14 and 03-21 dropped; Sundays 03-08 and 03-15 retained.

## Test plan
- [x] `train_dates_from_config()` returns 12 dates for the default config (was 14), Saturdays absent, Sundays present.
- [x] `--dates` CLI override is unaffected (it bypasses `train_dates_from_config`).

## Out of scope
US-holiday dates (e.g. Good Friday) still surface as downstream `run_backtest()` failures, same as today. Filtering those properly needs a market calendar (e.g. `pandas_market_calendars`) and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)