### PR TITLE
runner: enforce per-iteration wall-clock budget (issue #61)

### DIFF
--- a/research/config.yaml
+++ b/research/config.yaml
@@ -61,6 +61,15 @@ loop:
   max_iterations: 30
   # Stop after N consecutive FAIL outcomes (§5).
   stop_after_consecutive_failures: 3
+  # Per-iteration wall-clock budget for scripts/run_research_backtest.py.
+  # When set, the runner records a monotonic start time and refuses to
+  # begin a new (date, algo|baseline) backtest once elapsed exceeds this
+  # value — partial results from completed dates are aggregated as
+  # usual. Guards against the per-date cascade documented in issue #61
+  # where a wedged algorithm + 600s subprocess timeout could burn ~2
+  # hours of wall-clock before the iteration completed. Set to 0 or
+  # remove to disable.
+  iteration_timeout_seconds: 5400   # 90 minutes
 
 refinement:
   # Used when an iteration builds on a prior passing algorithm (§6). The

--- a/scripts/run_research_backtest.py
+++ b/scripts/run_research_backtest.py
@@ -50,6 +50,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -666,7 +667,28 @@ def main() -> int:
     base_metrics: dict[str, dict] = {}
     failures: list[tuple[str, str, str]] = []  # (algo_name, date, error)
 
+    # Iteration wall-clock budget (issue #61). Guards against the per-date
+    # cascade where a wedged algorithm + 600s subprocess timeout could burn
+    # ~2 hours of wall-clock before the iteration completed. 0 / missing
+    # disables. Checked at the *start* of each date — the in-flight
+    # subprocess (if any) is allowed to finish so we don't lose work that
+    # was about to land.
+    budget_sec = float(cfg.get("loop", {}).get("iteration_timeout_seconds", 0) or 0)
+    loop_start = time.monotonic()
+    budget_exceeded = False
+
     for date in dates:
+        if budget_sec > 0 and (time.monotonic() - loop_start) > budget_sec:
+            remaining = [d for d in dates[dates.index(date):]]
+            print(
+                f"\n⚠ ITERATION BUDGET EXCEEDED ({budget_sec:.0f}s). "
+                f"Skipping {len(remaining)} remaining date(s): "
+                f"{', '.join(remaining)}",
+                file=sys.stderr,
+            )
+            budget_exceeded = True
+            break
+
         if not args.baseline_only:
             print(f"\n>>> run_backtest({args.algo}, {date}) ...", flush=True)
             try:
@@ -744,7 +766,7 @@ def main() -> int:
 
         print_summary(algo_name=None, baseline_name=baseline,
                       algo_agg=None, base_agg=base_agg, cfg=cfg)
-        return 0 if not failures else 1
+        return 0 if not failures and not budget_exceeded else 1
 
     if not algo_metrics:
         print("\nERROR: no successful algo runs — cannot aggregate.", file=sys.stderr)
@@ -787,7 +809,7 @@ def main() -> int:
     print_summary(algo_name=args.algo, baseline_name=baseline,
                   algo_agg=algo_agg, base_agg=base_agg, cfg=cfg)
 
-    return 0 if not failures else 1
+    return 0 if not failures and not budget_exceeded else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `loop.iteration_timeout_seconds` to `research/config.yaml` (default 5400s = 90 min).
- Runner records a monotonic start time and refuses to begin a new (date, algo|baseline) backtest once elapsed exceeds the budget.
- Partial results from completed dates are aggregated; runner exits non-zero so the researcher logs the iteration as a FAIL.

## Why
Investigating #61, the per-date loop in `run_research_backtest.py` catches subprocess timeouts and continues to the next date. With a wedged algorithm and the 600s subprocess timeout, a single iteration could burn ~2 hours of wall-clock (`12 dates × 600s`) before completing. Multiplied across a continuous research loop, this becomes the observed "hot pulling until external kill" behavior in the bug report.

A wall-clock budget on the runner caps the worst case to `(budget + one in-flight subprocess timeout)` — the in-flight subprocess is allowed to finish so we don't lose work that was about to land.

The runner is where ~95% of an iteration's time goes; placing the budget there gives the highest leverage. The researcher gets a non-zero exit and logs the iteration as a FAIL, same as any other runner failure.

## Test plan
- [x] Set `iteration_timeout_seconds: 0.001` in a test config and ran with a 5-date window: date 1 attempted, budget check fired at the start of date 2, runner exited with "⚠ ITERATION BUDGET EXCEEDED" message and non-zero status. (See test output in commit message.)
- [x] Default config (5400s) is well above the observed ~29-min iteration time, so existing runs are unaffected.
- [ ] Reviewer: confirm that on a real wedge scenario the iteration bails cleanly at 90 min and the researcher logs the FAIL + commits.

## Disable
Set `loop.iteration_timeout_seconds: 0` or remove the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)