### PR TITLE
runner: lower per-date subprocess timeout from 600s to 180s (issue #61)

### DIFF
--- a/scripts/run_research_backtest.py
+++ b/scripts/run_research_backtest.py
@@ -72,7 +72,16 @@ DEFAULT_SYMBOL = "MESM6"
 # Per-backtest timeout for subprocess isolation. A 1-day backtest should
 # complete in well under 60s; this is a sanity ceiling, not a normal-case
 # limit. If you regularly bump this, something else is wrong.
-SUBPROCESS_TIMEOUT_SEC = 600
+#
+# Lowered from 600s to 180s as part of issue #61. The original 600s
+# existed primarily to absorb the memory-pressure tail when a Nautilus
+# engine pushed past available RAM and the OS started thrashing — a
+# wedged subprocess could stall for many minutes before either crashing
+# or finishing. With the RLIMIT_AS memory cap also added under #61, the
+# memory-pressure failure mode now raises MemoryError in seconds, so
+# the tail no longer exists and 180s gives ample headroom over the
+# ~27s observed for the simple baseline on the busiest cached day.
+SUBPROCESS_TIMEOUT_SEC = 180
 
 # Magic prefix on the child's stdout line carrying the result payload.
 # Anything goes after this prefix as long as it's a single line of JSON.


### PR DESCRIPTION
## Summary
- Lower `SUBPROCESS_TIMEOUT_SEC` from `600` to `180`.
- Add an in-code rationale referencing the memory-cap PR.

## Why
The original 600s timeout existed primarily to absorb the memory-pressure tail: when a Nautilus engine pushed past available RAM, the OS would thrash for many minutes before the subprocess either crashed or finished. With the `RLIMIT_AS` memory cap added under #73, that failure mode now raises `MemoryError` in seconds — the tail no longer exists.

180s gives a ~6× safety margin over the ~27s observed for the `simple` baseline on 20260312 (the busiest cached day: 2.2M ticks, 11k orders). If iterations regularly hit this ceiling, that's a signal something is genuinely wrong (algo logic, data scale, infra) — bumping the timeout is not the right fix.

## ⚠ Depends on #73
**This PR depends on #73 (RLIMIT_AS memory cap) being merged first.** Without the memory cap in place, genuine memory pressure on a busy day could exceed 180s and surface as a timeout failure instead of `MemoryError`. Merging this alone would make the bug in #61 worse, not better.

Recommended landing order:
1. #73 (memory cap)
2. This PR (lower timeout)
3. #74 (skip weekends), #75 (iteration budget) — independent, can land in any order

## Test plan
- [x] Smoke-checked the change is a one-constant edit; no behavior change in normal-case runs (well under 60s).
- [ ] Reviewer: confirm on the agent-loop host that with #73 in place, busy-day runs still complete in <180s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)