### PR TITLE
Make program_database meta block per-iteration (#78)

### DIFF
--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -65,8 +65,8 @@ The user prompt may be:
 5. **Append** to `research/program_database.json` per §9 (always — pass, close, or fail).
    Include the `meta` block as placeholders: `"meta": {"duration_seconds":
    null, "tokens_used": null}`. A `SubagentStop` hook backfills both fields
-   from the transcript after you stop — do **not** try to compute them
-   yourself.
+   from this iteration's transcript slice after you stop — do **not** try to
+   compute them yourself.
 6. **On PASS**: snapshot per the `snapshot` skill. On CLOSE or FAIL: do not snapshot.
 7. **Commit on a fresh iteration branch** (one branch per invocation, so the
    base branch stays clean):

--- a/.claude/hooks/patch_program_db_tokens.py
+++ b/.claude/hooks/patch_program_db_tokens.py
@@ -1,26 +1,36 @@
 #!/usr/bin/env python3
 """SubagentStop hook: backfill the `meta` block of the most-recent entry in
-research/program_database.json with execution metadata from the just-stopped
-subagent's transcript.
+research/program_database.json with per-iteration execution metadata from the
+just-stopped subagent's transcript.
 
 Triggered on every SubagentStop. The hook is a no-op unless the most-recent
 entry has `meta.duration_seconds is None` AND `meta.tokens_used is None` (the
 researcher's marker that this entry expects a backfill). Subagents that are
 not the researcher leave the file untouched.
 
-Computes:
-  - meta.duration_seconds: wall-clock seconds from first to last transcript
-    message, parsed from the per-message `timestamp` field.
+Per-iteration scoping. The researcher subagent's transcript persists and
+grows when the loop driver continues the same subagent across research-loop
+iterations. Scanning the whole transcript every time would make each entry
+cumulative (issue #78). Instead, an offset cursor at
+`research/.meta_cursor.json` records how many transcript lines have already
+been consumed; each run scans only the new slice. The cursor is machine-local
+runtime state (it stores an absolute transcript path) and is git-ignored. If
+it is missing or stale, the hook re-scans from the start -- over-counting at
+worst once, never under-counting.
+
+Computes (over the current iteration's slice only):
+  - meta.duration_seconds: wall-clock seconds from the slice's first
+    transcript message to its last, parsed from the per-message `timestamp`.
   - meta.tokens_used: {"input": ..., "output": ..., "cache_creation": ...,
-    "cache_read": ..., "total": ...} summed across every message that
-    carries a `usage` block in the transcript.
+    "cache_read": ..., "total": ...} summed across every transcript record
+    in the slice that carries a `usage` block.
 
 After patching, attempts a `chore(<algo-id>): backfill execution metadata`
 commit so the working tree stays clean, then attempts
 `git push --set-upstream origin <branch>` if the current branch is an
 `iter/*` branch. Both steps are best-effort: a failure (pre-commit hook,
 dirty unrelated files, no git, no remote, no auth, etc.) is silently
-ignored — the local commit stays in place and the user can push manually.
+ignored -- the local commit stays in place and the user can push manually.
 """
 from __future__ import annotations
 
@@ -42,16 +52,36 @@ def _parse_ts(raw: str | None) -> datetime | None:
         return None
 
 
-def _scan_transcript(transcript_path: Path) -> tuple[dict[str, int] | None, float | None]:
-    """Return (token totals, duration_seconds). Either may be None on failure."""
+def _scan_transcript(
+    transcript_path: Path,
+    start_line: int = 0,
+) -> tuple[dict[str, int] | None, float | None, int]:
+    """Scan transcript lines [start_line, EOF) for token totals and duration.
+
+    Returns (token_totals, duration_seconds, lines_seen):
+      - token_totals / duration_seconds are computed ONLY over the slice of
+        lines at index >= start_line. Either may be None when that slice
+        carries no usage blocks / no timestamps.
+      - lines_seen is the TOTAL physical line count of the file (including
+        lines before start_line) -- the next cursor value. On an OSError it
+        is 0, which signals "unreadable; do not advance the cursor".
+
+    A physical-line offset is used (not a record index) because the transcript
+    is append-only JSONL: line N keeps its content across runs, and the count
+    is immune to JSON parse failures and blank lines.
+    """
     totals = {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0}
     saw_usage = False
     first_ts: datetime | None = None
     last_ts: datetime | None = None
+    lines_seen = 0
 
     try:
         with transcript_path.open() as f:
-            for line in f:
+            for idx, line in enumerate(f):
+                lines_seen = idx + 1
+                if idx < start_line:
+                    continue  # Already consumed by a prior iteration.
                 line = line.strip()
                 if not line:
                     continue
@@ -75,7 +105,7 @@ def _scan_transcript(transcript_path: Path) -> tuple[dict[str, int] | None, floa
                     totals["cache_creation"] += int(usage.get("cache_creation_input_tokens", 0) or 0)
                     totals["cache_read"] += int(usage.get("cache_read_input_tokens", 0) or 0)
     except OSError:
-        return None, None
+        return None, None, 0
 
     token_totals: dict[str, int] | None = None
     if saw_usage:
@@ -86,7 +116,45 @@ def _scan_transcript(transcript_path: Path) -> tuple[dict[str, int] | None, floa
     if first_ts is not None and last_ts is not None and last_ts >= first_ts:
         duration = (last_ts - first_ts).total_seconds()
 
-    return token_totals, duration
+    return token_totals, duration, lines_seen
+
+
+def _read_cursor(cursor_path: Path) -> dict[str, Any] | None:
+    """Return the cursor state `{"transcript_path": str, "lines_consumed":
+    int >= 0}`, or None when the file is absent, unreadable, corrupt, or has
+    the wrong shape. A None result makes the caller scan from line 0."""
+    try:
+        data = json.loads(cursor_path.read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    tp = data.get("transcript_path")
+    lc = data.get("lines_consumed")
+    # bool is a subclass of int -- reject it explicitly.
+    if not isinstance(tp, str) or isinstance(lc, bool) or not isinstance(lc, int) or lc < 0:
+        return None
+    return {"transcript_path": tp, "lines_consumed": lc}
+
+
+def _write_cursor(cursor_path: Path, transcript_path: Path, lines_consumed: int) -> None:
+    """Best-effort: persist the offset cursor so the next SubagentStop scans
+    only new transcript lines. A failure here is non-fatal -- the next run
+    finds no/old cursor and re-scans from the start, which over-counts at
+    worst once and never under-counts."""
+    try:
+        cursor_path.write_text(
+            json.dumps(
+                {
+                    "transcript_path": str(transcript_path),
+                    "lines_consumed": lines_consumed,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+    except OSError:
+        return  # Best-effort: next run resets to a full scan.
 
 
 def _try_commit(cwd: str, algo_id: str) -> None:
@@ -164,7 +232,9 @@ def main() -> None:
     meta = last.get("meta")
     if not isinstance(meta, dict):
         return
-    # Only patch entries the researcher explicitly marked for backfill.
+    # Only patch entries the researcher explicitly marked for backfill. This
+    # early-return runs before the cursor is read, so an already-backfilled
+    # entry never advances the cursor.
     if meta.get("tokens_used") is not None or meta.get("duration_seconds") is not None:
         return
 
@@ -172,9 +242,24 @@ def main() -> None:
     if not transcript_path.exists():
         return
 
-    token_totals, duration = _scan_transcript(transcript_path)
+    # The transcript persists and grows when the loop driver continues the same
+    # researcher subagent across iterations. Scan only the slice produced since
+    # the last backfill so each entry records its own iteration, not a running
+    # total (issue #78). The cursor lives next to the database and is git-ignored.
+    cursor_path = Path(cwd) / "research" / ".meta_cursor.json"
+    cursor = _read_cursor(cursor_path)
+    start_line = 0
+    if cursor is not None and cursor["transcript_path"] == str(transcript_path):
+        start_line = cursor["lines_consumed"]
+
+    token_totals, duration, lines_seen = _scan_transcript(transcript_path, start_line)
+
+    # Cursor pointed past EOF (transcript truncated or rotated) -> rescan whole.
+    if start_line > lines_seen:
+        token_totals, duration, lines_seen = _scan_transcript(transcript_path, 0)
+
     if token_totals is None and duration is None:
-        return  # Nothing useful extracted; skip silently
+        return  # Empty slice / nothing useful; leave the cursor unadvanced.
 
     if token_totals is not None:
         last["meta"]["tokens_used"] = token_totals
@@ -182,6 +267,10 @@ def main() -> None:
         last["meta"]["duration_seconds"] = round(duration, 1)
 
     db_path.write_text(json.dumps(db, indent=2) + "\n")
+
+    # Advance the cursor only after a real backfill consumed this slice, and
+    # before the git steps so a commit/push failure cannot lose the progress.
+    _write_cursor(cursor_path, transcript_path, lines_seen)
 
     algo_id = str(last.get("id") or "unknown")
     _try_commit(cwd, algo_id)

--- a/.claude/hooks/patch_program_db_tokens.py
+++ b/.claude/hooks/patch_program_db_tokens.py
@@ -1,22 +1,28 @@
 #!/usr/bin/env python3
 """SubagentStop hook: backfill the `meta` block of the most-recent entry in
 research/program_database.json with per-iteration execution metadata from the
-just-stopped subagent's transcript.
+main session transcript.
 
 Triggered on every SubagentStop. The hook is a no-op unless the most-recent
 entry has `meta.duration_seconds is None` AND `meta.tokens_used is None` (the
 researcher's marker that this entry expects a backfill). Subagents that are
 not the researcher leave the file untouched.
 
-Per-iteration scoping. The researcher subagent's transcript persists and
-grows when the loop driver continues the same subagent across research-loop
-iterations. Scanning the whole transcript every time would make each entry
-cumulative (issue #78). Instead, an offset cursor at
+Per-iteration scoping. The `transcript_path` a SubagentStop hook receives is
+the main session transcript -- the parent conversation file, which
+accumulates across every subagent invocation in the session. It is NOT the
+just-stopped subagent's own transcript. Scanning the whole file every time
+would make each entry cumulative (issue #78). Instead, an offset cursor at
 `research/.meta_cursor.json` records how many transcript lines have already
 been consumed; each run scans only the new slice. The cursor is machine-local
 runtime state (it stores an absolute transcript path) and is git-ignored. If
 it is missing or stale, the hook re-scans from the start -- over-counting at
 worst once, never under-counting.
+
+Because the transcript is the main session's, `meta` measures the session
+slice between SubagentStop firings, not the researcher subagent's own compute
+(which lives in a separate `subagents/agent-<id>.jsonl`). See issue #88 for
+the follow-up to scan the per-subagent transcript instead.
 
 Computes (over the current iteration's slice only):
   - meta.duration_seconds: wall-clock seconds from the slice's first

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ temp/
 tmp/
 docs/oracle_strategy_implementation.md
 /NautilusDocs
+
+# Local hook state (per-iteration metadata cursor) -- machine-local, do not commit
+research/.meta_cursor.json

--- a/docs/OBJECTIVE.md
+++ b/docs/OBJECTIVE.md
@@ -442,13 +442,20 @@ The agent writes `"meta": {"duration_seconds": null, "tokens_used": null}` as
 placeholders when appending the entry — both fields are diagnostic and do
 **not** affect the gate. A `SubagentStop` hook
 (`.claude/hooks/patch_program_db_tokens.py`, registered in
-`.claude/settings.json`) then backfills both from the subagent's transcript:
+`.claude/settings.json`) then backfills both with **per-iteration** values:
 
-- `duration_seconds` — wall-clock seconds from the subagent's first
-  message to its last message.
+- `duration_seconds` — wall-clock seconds covering **this iteration's**
+  slice of the subagent transcript (first to last message of the slice).
 - `tokens_used` — `{"input": ..., "output": ..., "cache_creation": ...,
-  "cache_read": ..., "total": ...}` summed across every assistant message
-  in the transcript.
+  "cache_read": ..., "total": ...}` summed across the transcript records
+  produced **during this iteration**.
+
+The researcher's subagent transcript can persist and grow across loop
+iterations, so the hook scopes each backfill with an offset cursor
+(`research/.meta_cursor.json`, git-ignored, machine-local): it scans only
+the transcript lines added since the previous backfill. If the hook is
+skipped or fails for an iteration, the next iteration's metadata covers
+both iterations combined.
 
 The hook auto-commits the patch as `chore(<algo-id>): backfill execution
 metadata` so the working tree stays clean. If the hook is disabled or

--- a/docs/OBJECTIVE.md
+++ b/docs/OBJECTIVE.md
@@ -445,17 +445,19 @@ placeholders when appending the entry — both fields are diagnostic and do
 `.claude/settings.json`) then backfills both with **per-iteration** values:
 
 - `duration_seconds` — wall-clock seconds covering **this iteration's**
-  slice of the subagent transcript (first to last message of the slice).
+  slice of the session transcript (first to last message of the slice).
 - `tokens_used` — `{"input": ..., "output": ..., "cache_creation": ...,
   "cache_read": ..., "total": ...}` summed across the transcript records
   produced **during this iteration**.
 
-The researcher's subagent transcript can persist and grow across loop
-iterations, so the hook scopes each backfill with an offset cursor
-(`research/.meta_cursor.json`, git-ignored, machine-local): it scans only
-the transcript lines added since the previous backfill. If the hook is
-skipped or fails for an iteration, the next iteration's metadata covers
-both iterations combined.
+The `transcript_path` a `SubagentStop` hook receives is the main session
+transcript, which accumulates across every subagent invocation, so the hook
+scopes each backfill with an offset cursor (`research/.meta_cursor.json`,
+git-ignored, machine-local): it scans only the transcript lines added since
+the previous backfill. If the hook is skipped or fails for an iteration, the
+next iteration's metadata covers both iterations combined. (Because it reads
+the session transcript, `meta` reflects the per-iteration session slice, not
+the researcher subagent's own compute — see issue #88.)
 
 The hook auto-commits the patch as `chore(<algo-id>): backfill execution
 metadata` so the working tree stays clean. If the hook is disabled or

--- a/tests/test_patch_program_db_tokens.py
+++ b/tests/test_patch_program_db_tokens.py
@@ -1,0 +1,304 @@
+"""Verify the per-iteration metadata backfill (`.claude/hooks/patch_program_db_tokens.py`).
+
+The hook's correctness claim (issue #78): when the researcher subagent's
+transcript persists and grows across research-loop iterations, each
+`program_database.json` entry must record *its own* iteration's duration and
+tokens — not a running total. An offset cursor (`research/.meta_cursor.json`)
+makes the hook scan only the transcript slice produced since the last backfill.
+
+These tests build synthetic transcripts and drive the hook the way the harness
+does — a JSON payload on stdin — asserting per-iteration deltas, not cumulative.
+
+No pytest required — run it directly:
+
+    python tests/test_patch_program_db_tokens.py
+
+It is also pytest-collectable. The git-isolation test skips cleanly when `git`
+is not on PATH; everything else is pure-Python and always runs.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_PATH = REPO_ROOT / ".claude" / "hooks" / "patch_program_db_tokens.py"
+
+# The hook lives under a dotted directory and is not an importable package;
+# load it straight from its file path.
+_spec = importlib.util.spec_from_file_location("patch_program_db_tokens", HOOK_PATH)
+hook = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hook)
+
+
+# --- Expected per-iteration aggregates of the synthetic transcript below ------
+# iteration 1 == transcript lines 0-3, iteration 2 == lines 4-7.
+ITER1_TOKENS = {"input": 18, "output": 7, "cache_creation": 100, "cache_read": 500, "total": 625}
+ITER1_DURATION = 100.0  # 00:00:00 -> 00:01:40
+ITER2_TOKENS = {"input": 15, "output": 15, "cache_creation": 50, "cache_read": 10000, "total": 10080}
+ITER2_DURATION = 60.0  # 00:10:00 -> 00:11:00
+COMBINED_TOKENS = {"input": 33, "output": 22, "cache_creation": 150, "cache_read": 10500, "total": 10705}
+COMBINED_DURATION = 660.0  # 00:00:00 -> 00:11:00
+
+
+def _usage(inp, out, cc, cr):
+    return {
+        "input_tokens": inp,
+        "output_tokens": out,
+        "cache_creation_input_tokens": cc,
+        "cache_read_input_tokens": cr,
+    }
+
+
+def _iter1_lines():
+    """4 transcript records: 3 carry usage, one is a usage-less user turn."""
+    return [
+        {"timestamp": "2026-01-01T00:00:00Z", "message": {"role": "assistant", "usage": _usage(10, 1, 100, 0)}},
+        {"timestamp": "2026-01-01T00:00:30Z", "message": {"role": "assistant", "usage": _usage(5, 2, 0, 200)}},
+        {"timestamp": "2026-01-01T00:01:00Z", "message": {"role": "user"}},
+        {"timestamp": "2026-01-01T00:01:40Z", "message": {"role": "assistant", "usage": _usage(3, 4, 0, 300)}},
+    ]
+
+
+def _iter2_lines():
+    """4 transcript records: 4 carry usage, one of them has no timestamp."""
+    return [
+        {"timestamp": "2026-01-01T00:10:00Z", "message": {"role": "assistant", "usage": _usage(1, 1, 50, 1000)}},
+        {"timestamp": "2026-01-01T00:10:20Z", "message": {"role": "assistant", "usage": _usage(2, 2, 0, 2000)}},
+        {"message": {"role": "assistant", "usage": _usage(4, 4, 0, 3000)}},
+        {"timestamp": "2026-01-01T00:11:00Z", "message": {"role": "assistant", "usage": _usage(8, 8, 0, 4000)}},
+    ]
+
+
+def _write_jsonl(path: Path, records):
+    path.write_text("".join(json.dumps(r) + "\n" for r in records))
+
+
+def _db_entry(algo_id: str):
+    """A minimal program_database entry with the researcher's backfill marker."""
+    return {"id": algo_id, "status": "fail", "meta": {"duration_seconds": None, "tokens_used": None}}
+
+
+def _load_json(path: Path):
+    return json.loads(path.read_text())
+
+
+def _run_hook(cwd: Path, transcript_path: Path) -> subprocess.CompletedProcess:
+    """Drive the hook exactly as a SubagentStop fires it: a JSON stdin payload."""
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=json.dumps({"transcript_path": str(transcript_path), "cwd": str(cwd)}),
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_scan_slice_math():
+    """`_scan_transcript` sums tokens/duration over [start_line, EOF) only."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "t.jsonl"
+        _write_jsonl(path, _iter1_lines() + _iter2_lines())
+
+        # Whole file == both iterations combined.
+        tok, dur, seen = hook._scan_transcript(path, 0)
+        assert tok == COMBINED_TOKENS, tok
+        assert dur == COMBINED_DURATION, dur
+        assert seen == 8, seen
+
+        # Slice from line 4 == iteration 2 only (NOT cumulative).
+        tok, dur, seen = hook._scan_transcript(path, 4)
+        assert tok == ITER2_TOKENS, tok
+        assert dur == ITER2_DURATION, dur
+        assert seen == 8, seen
+
+        # Empty slice (cursor already at EOF).
+        tok, dur, seen = hook._scan_transcript(path, 8)
+        assert tok is None and dur is None, (tok, dur)
+        assert seen == 8, seen
+
+        # A slice with a single timestamped record -> zero measured span.
+        tok, dur, seen = hook._scan_transcript(path, 7)
+        assert dur == 0.0, dur
+        assert tok == {"input": 8, "output": 8, "cache_creation": 0, "cache_read": 4000, "total": 4016}, tok
+
+
+def test_per_iteration_backfill_across_invocations():
+    """Two SubagentStop firings on a growing transcript -> per-iteration meta."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        (repo / "research").mkdir()
+        db_path = repo / "research" / "program_database.json"
+        cursor_path = repo / "research" / ".meta_cursor.json"
+        transcript = repo / "transcript.jsonl"
+
+        # --- Iteration 1 -----------------------------------------------------
+        db_path.write_text(json.dumps([_db_entry("algo-one")], indent=2) + "\n")
+        _write_jsonl(transcript, _iter1_lines())
+        proc = _run_hook(repo, transcript)
+        assert proc.returncode == 0, proc.stderr
+
+        db = _load_json(db_path)
+        assert db[0]["meta"]["tokens_used"] == ITER1_TOKENS, db[0]["meta"]
+        assert db[0]["meta"]["duration_seconds"] == ITER1_DURATION, db[0]["meta"]
+
+        cursor = _load_json(cursor_path)
+        assert cursor == {"transcript_path": str(transcript), "lines_consumed": 4}, cursor
+
+        # --- Iteration 2: transcript grows, a new entry is appended ----------
+        _write_jsonl(transcript, _iter1_lines() + _iter2_lines())
+        db.append(_db_entry("algo-two"))
+        db_path.write_text(json.dumps(db, indent=2) + "\n")
+        proc = _run_hook(repo, transcript)
+        assert proc.returncode == 0, proc.stderr
+
+        db = _load_json(db_path)
+        # The crux of issue #78: entry 2 gets ONLY iteration 2's cost.
+        assert db[1]["meta"]["tokens_used"] == ITER2_TOKENS, db[1]["meta"]
+        assert db[1]["meta"]["tokens_used"]["input"] == 15, "must be per-iteration, not the cumulative 33"
+        assert db[1]["meta"]["duration_seconds"] == ITER2_DURATION, db[1]["meta"]
+        # Entry 1 is untouched (append-only; already backfilled).
+        assert db[0]["meta"]["tokens_used"] == ITER1_TOKENS, db[0]["meta"]
+        assert _load_json(cursor_path)["lines_consumed"] == 8
+
+        # --- Iteration 3: nothing new -> already-backfilled early-return -----
+        proc = _run_hook(repo, transcript)
+        assert proc.returncode == 0, proc.stderr
+        assert _load_json(db_path) == db, "an already-backfilled entry must not change"
+        assert _load_json(cursor_path)["lines_consumed"] == 8, "cursor must not advance"
+
+
+def test_truncated_transcript_rescans_from_zero():
+    """A cursor pointing past EOF (rotated/truncated transcript) re-scans whole."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        (repo / "research").mkdir()
+        db_path = repo / "research" / "program_database.json"
+        cursor_path = repo / "research" / ".meta_cursor.json"
+        transcript = repo / "transcript.jsonl"
+
+        db_path.write_text(json.dumps([_db_entry("algo-trunc")], indent=2) + "\n")
+        _write_jsonl(transcript, _iter1_lines())  # only 4 lines
+        # Cursor claims 100 lines already consumed -> stale / past EOF.
+        cursor_path.write_text(json.dumps({"transcript_path": str(transcript), "lines_consumed": 100}))
+
+        proc = _run_hook(repo, transcript)
+        assert proc.returncode == 0, proc.stderr
+
+        db = _load_json(db_path)
+        assert db[0]["meta"]["tokens_used"] == ITER1_TOKENS, db[0]["meta"]
+        assert db[0]["meta"]["duration_seconds"] == ITER1_DURATION, db[0]["meta"]
+        assert _load_json(cursor_path)["lines_consumed"] == 4, "cursor reset to true length"
+
+
+def test_corrupt_cursor_scans_from_zero():
+    """An unreadable cursor file degrades to a full scan, never a crash."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        (repo / "research").mkdir()
+        db_path = repo / "research" / "program_database.json"
+        cursor_path = repo / "research" / ".meta_cursor.json"
+        transcript = repo / "transcript.jsonl"
+
+        db_path.write_text(json.dumps([_db_entry("algo-corrupt")], indent=2) + "\n")
+        _write_jsonl(transcript, _iter1_lines())
+        cursor_path.write_text("this is not json {{{")
+
+        proc = _run_hook(repo, transcript)
+        assert proc.returncode == 0, proc.stderr
+
+        db = _load_json(db_path)
+        assert db[0]["meta"]["tokens_used"] == ITER1_TOKENS, db[0]["meta"]
+        # The corrupt cursor was overwritten with a valid one.
+        assert _load_json(cursor_path) == {"transcript_path": str(transcript), "lines_consumed": 4}
+
+
+def test_read_cursor_rejects_bad_shapes():
+    """`_read_cursor` returns None for anything that isn't a well-formed cursor."""
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / ".meta_cursor.json"
+        assert hook._read_cursor(p) is None  # absent
+        p.write_text("{not json")
+        assert hook._read_cursor(p) is None  # unparseable
+        p.write_text("[1, 2, 3]")
+        assert hook._read_cursor(p) is None  # not an object
+        p.write_text(json.dumps({"transcript_path": "/x"}))
+        assert hook._read_cursor(p) is None  # missing lines_consumed
+        p.write_text(json.dumps({"transcript_path": "/x", "lines_consumed": "5"}))
+        assert hook._read_cursor(p) is None  # lines_consumed wrong type
+        p.write_text(json.dumps({"transcript_path": "/x", "lines_consumed": True}))
+        assert hook._read_cursor(p) is None  # bool must not pass as int
+        p.write_text(json.dumps({"transcript_path": "/x", "lines_consumed": -1}))
+        assert hook._read_cursor(p) is None  # negative
+        p.write_text(json.dumps({"transcript_path": "/x", "lines_consumed": 7}))
+        assert hook._read_cursor(p) == {"transcript_path": "/x", "lines_consumed": 7}
+
+
+def test_cursor_excluded_from_backfill_commit():
+    """The auto-commit stages only program_database.json; the cursor stays out."""
+    if shutil.which("git") is None:
+        print("SKIP: git not on PATH")
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+
+        def git(*args):
+            subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+        def git_out(*args):
+            return subprocess.run(
+                ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+            ).stdout
+
+        git("init", "-q")
+        git("config", "user.email", "test@example.com")
+        git("config", "user.name", "Test")
+        git("config", "commit.gpgsign", "false")
+        # Neutralize any global core.hooksPath so a stray pre-commit hook can't fire.
+        git("config", "core.hooksPath", str(repo / ".no-such-hooks"))
+
+        (repo / "research").mkdir()
+        (repo / ".gitignore").write_text("research/.meta_cursor.json\n")
+        db_path = repo / "research" / "program_database.json"
+        db_path.write_text(json.dumps([_db_entry("algo-git")], indent=2) + "\n")
+        git("add", "-A")
+        git("commit", "-q", "-m", "initial")
+
+        transcript = repo / "transcript.jsonl"
+        _write_jsonl(transcript, _iter1_lines())
+
+        proc = _run_hook(repo, transcript)
+        assert proc.returncode == 0, proc.stderr
+
+        # The hook produced one backfill commit...
+        assert git_out("log", "--format=%s").splitlines()[0] == (
+            "chore(algo-git): backfill execution metadata"
+        )
+        # ...touching only the database file.
+        files = git_out("show", "--name-only", "--format=", "HEAD").split()
+        assert files == ["research/program_database.json"], files
+        # The cursor exists on disk, is git-ignored, and is not a tracked change.
+        assert (repo / "research" / ".meta_cursor.json").exists()
+        assert ".meta_cursor.json" in git_out("status", "--porcelain", "--ignored")
+        assert ".meta_cursor.json" not in git_out("status", "--porcelain")
+
+
+if __name__ == "__main__":
+    tests = [
+        test_scan_slice_math,
+        test_per_iteration_backfill_across_invocations,
+        test_truncated_transcript_rescans_from_zero,
+        test_corrupt_cursor_scans_from_zero,
+        test_read_cursor_rejects_bad_shapes,
+        test_cursor_excluded_from_backfill_commit,
+    ]
+    for t in tests:
+        print(f"... {t.__name__}", flush=True)
+        t()
+        print(f"PASS {t.__name__}")
+    print(f"\nAll {len(tests)} tests passed.")


### PR DESCRIPTION
## Context

Closes #78. The `meta` block of each entry in `research/program_database.json` (`duration_seconds`, `tokens_used`) was **cumulative** — it grew across research-loop iterations instead of recording the cost of that one iteration.

## Root cause

The `SubagentStop` hook `.claude/hooks/patch_program_db_tokens.py` backfills the `meta` block via `_scan_transcript()`, which scanned the **entire** transcript JSONL — summing every `message.usage` block and taking `last_ts − first_ts` over all records. The `transcript_path` a `SubagentStop` hook receives is the **main session transcript** — the parent conversation `.jsonl` — which accumulates across every subagent invocation in the session (it is *not* the just-stopped subagent's own transcript). So each backfill re-counted the whole session from its start, making `duration_seconds` and `tokens_used` cumulative.

Confirmed empirically: a verification run recorded the cursor's `transcript_path` as the top-level session `.jsonl`, and the first backfill (no prior cursor) scanned from line 0 and captured the entire enclosing session.

## Fix

An **offset cursor** at `research/.meta_cursor.json` records how many transcript lines the hook has already consumed; each `SubagentStop` scans only the new slice. Robust whether the transcript is fresh per iteration or continued/growing, and degrades to a full rescan on a missing/stale/corrupt cursor (over-counts at worst once, never under-counts).

Per-iteration values **replace** the cumulative ones (no parallel `*_cumulative` fields).

## Changes

| File | Change |
|---|---|
| `.claude/hooks/patch_program_db_tokens.py` | `_scan_transcript` takes a `start_line` and returns the total line count; new `_read_cursor`/`_write_cursor` helpers; `main()` reads the cursor, scans the slice, advances it after a successful backfill. `_try_commit` already stages an explicit pathspec, so the cursor never enters the commit. |
| `.gitignore` | Ignores `research/.meta_cursor.json` (machine-local hook state — it stores an absolute transcript path). |
| `docs/OBJECTIVE.md` | §9 "Execution metadata" reworded to per-iteration; documents the cursor and the skipped-iteration caveat. |
| `.claude/agents/researcher.md` | One-line wording tweak. |
| `tests/test_patch_program_db_tokens.py` | **New** committed test. |

The live `research/program_database.json` is untouched — its single entry already has a non-null `meta`, so the hook's early-return skips it.

## Edge cases handled

First run (no cursor) · transcript path changes · hook skipped/failed for an iteration (stale cursor → next run covers both combined) · entry already backfilled (cursor not advanced) · corrupt/unreadable cursor · `lines_consumed` past EOF (truncated/rotated → rescan from 0) · single-timestamp slice (`duration == 0.0`) · empty slice.

## Testing

`python3 tests/test_patch_program_db_tokens.py` — **all 6 pass**:
- `_scan_transcript` slice math (combined vs. iteration-2-only vs. empty vs. single-timestamp)
- two simulated `SubagentStop` firings on a growing transcript — proves entry 2 gets only iteration-2 deltas (`input` = 15, **not** the cumulative 33)
- truncated transcript rescans from 0
- corrupt cursor degrades to a full scan without crashing
- `_read_cursor` rejects malformed shapes
- git-repo test confirming the cursor stays out of the backfill commit

Also verified live: a two-iteration researcher run on this branch confirmed iteration 2's `meta` was scoped to its own slice (961K tokens / 45.5s) rather than cumulative (~10.08M) — the cursor advanced 226 → 238 lines between `SubagentStop` firings.

## Follow-up

**#88** — because the hook reads the *main session* transcript, `meta` reflects the per-iteration session slice (the loop driver's overhead), not the researcher subagent's own compute, which lives in a separate `subagents/agent-<id>.jsonl`. Out of scope here (#78 only asked for non-cumulative metadata); tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)