### PR TITLE
Horizon-hold `simple` execution baseline (experimental — sweep shows regression)

### DIFF
--- a/backtest_engine/backtest_low_level.py
+++ b/backtest_engine/backtest_low_level.py
@@ -108,6 +108,13 @@ def run_backtest(
         strategy_options.setdefault("trade_size", Decimal("1"))
     if execution_algorithm_name == "simple":
         execution_options.setdefault("exec_id", "MY_GENERIC_ALGO")
+        # The baseline holds each position for the oracle's forecast horizon.
+        # Keep config.yaml -> strategy.kwargs.horizon_seconds as the single source
+        # of truth and pass it through to the execution algorithm.
+        if oracle_options is not None:
+            execution_options.setdefault(
+                "horizon_seconds", oracle_options["horizon_seconds"]
+            )
 
     strategy = create_strategy(strategy_name, **strategy_options)
     engine.add_strategy(strategy=strategy)

--- a/execution_algos/simple_execution_strategy/execution_algorithm.py
+++ b/execution_algos/simple_execution_strategy/execution_algorithm.py
@@ -3,37 +3,87 @@ from nautilus_trader.execution.config import ExecAlgorithmConfig
 from nautilus_trader.model.identifiers import ExecAlgorithmId
 
 
-class SimpleExecutionAlgorithmConfig(ExecAlgorithmConfig):
-    pass
+class SimpleExecutionAlgorithmConfig(ExecAlgorithmConfig, frozen=True):
+    """Baseline config.
+
+    `horizon_seconds` must match the oracle strategy's forecast horizon — it is
+    wired from `config.yaml -> strategy.kwargs.horizon_seconds` by run_backtest().
+    """
+
+    horizon_seconds: float = 30.0
 
 
 class SimpleExecutionAlgorithm(ExecAlgorithm):
+    """Horizon-hold baseline execution algorithm.
+
+    Holds each position for `horizon_seconds`, skipping the strategy's intermediate
+    reversal orders, then resumes following the oracle at the first flip after the
+    horizon elapses.
+
+    The oracle strategy is always-in-market: it emits a reduce-only close plus a new
+    open on every signal direction change. A pure pass-through therefore pays a full
+    bid-ask spread on every flip. When the oracle is noisy (high sigma) it flips
+    roughly every signal interval, so the pass-through bleeds the spread on a
+    near-coin-flip ~once per second.
+
+    This algorithm forwards an opening order, then skips every subsequent order until
+    `horizon_seconds` has elapsed since entry; the first flip after that point exits
+    the position (close forwarded) and re-enters on the current oracle direction
+    (paired open forwarded). Round-trips — and spread cost — drop by roughly
+    horizon / flip-interval, and each holding window matches the oracle's forecast
+    horizon, so a trade realizes the quantity the oracle actually forecast.
+
+    Uses only `submit_order` (forward) and skipping (return without submitting) — it
+    never originates or inflates an order, so `sum(child_fills) <= parent.quantity`
+    holds trivially.
     """
-    A custom execution algorithm that demonstrates simple order handling.
-    It immediately executes the incoming order in full.
-    """
+
+    def __init__(self, config: SimpleExecutionAlgorithmConfig) -> None:
+        super().__init__(config=config)
+        self._horizon_ns: int = int(config.horizon_seconds * 1_000_000_000)
+        self._holding: bool = False
+        self._entry_ts: int = 0
 
     def on_start(self) -> None:
-        self.log.info("SimpleExecutionAlgorithm started.")
-
-    def on_reset(self) -> None:
-        pass
-
-    def on_order(self, order) -> None:
-        """
-        Intercepts incoming orders from strategies.
-        """
         self.log.info(
-            f"SimpleExecutionAlgorithm handling order: {order.client_order_id} for {order.quantity}"
+            f"SimpleExecutionAlgorithm started (horizon={self._horizon_ns / 1e9:.1f}s)."
         )
 
-        # Pass the order directly to the venue backend.
-        self.submit_order(order)
+    def on_reset(self) -> None:
+        self._holding = False
+        self._entry_ts = 0
+
+    def on_order(self, order) -> None:
+        """Forward or skip the incoming order to enforce a `horizon_seconds` hold."""
+        now = order.ts_init
+
+        if not getattr(order, "is_reduce_only", False):
+            # OPEN leg.
+            if self._holding:
+                return  # Mid-hold: ignore the intermediate entry.
+            self.submit_order(order)
+            self._holding = True
+            self._entry_ts = now
+            return
+
+        # CLOSE leg (reduce-only).
+        if not self._holding:
+            return  # No position to close.
+        if now - self._entry_ts >= self._horizon_ns:
+            # Horizon elapsed — let this flip's close exit the position. The paired
+            # open that follows re-enters on the current oracle direction.
+            self.submit_order(order)
+            self._holding = False
+        # else: mid-hold — ignore the reversal close.
 
 
-def get_execution_algorithm(exec_id: str = "MY_GENERIC_ALGO"):
-    """
-    Instantiate and return the custom execution algorithm.
-    """
-    config = SimpleExecutionAlgorithmConfig(exec_algorithm_id=ExecAlgorithmId(exec_id))
+def get_execution_algorithm(
+    exec_id: str = "MY_GENERIC_ALGO",
+    horizon_seconds: float = 30.0,
+) -> SimpleExecutionAlgorithm:
+    """Instantiate and return the horizon-hold baseline execution algorithm."""
+    config = SimpleExecutionAlgorithmConfig(
+        exec_algorithm_id=ExecAlgorithmId(exec_id),
+        horizon_seconds=horizon_seconds,
+    )
     return SimpleExecutionAlgorithm(config=config)


### PR DESCRIPTION
## Summary

Replaces the pass-through `simple` execution algorithm (the pass-gate baseline) with a **horizon-hold** variant, and wires `horizon_seconds` from the oracle strategy config into the algorithm.

**Horizon-hold behavior:** forward an opening order, then skip the oracle strategy's intermediate reversal orders until `horizon_seconds` has elapsed since entry; the first flip after that point exits the position and re-enters on the current oracle direction. Each position is therefore held for ~the oracle's forecast horizon (~30 s), using only forward/skip — no order origination.

## ⚠️ Experimental — this is a regression, not an improvement

The goal was a baseline that stays profitable at high sigma (≈1 bp R²). A sigma sweep over 5 train dates (20260308–12) shows the horizon-hold loses at **every** sigma tested:

| sigma | realized P&L (5 dates) | win rate |
|------:|-----------------------:|---------:|
| 217.67 | −556.00 | 45.2% |
| 200.0  | −548.50 | 45.2% |
| 150.0  | −537.50 | 45.2% |
| 100.0  | −467.50 | 45.5% |
| 50.0   | −398.50 | 45.6% |

The original pass-through baseline was marginally *profitable* at sigma=5 (+$1,699 / 11 dates), so this change underperforms it.

## Root cause

Win rate stays flat (~45%) as the signal gets ~19× stronger (sigma 217→50), which means the horizon-hold trades never capture the oracle's forecast. The oracle strategy only emits orders at **flips** — the moments the forecast crosses zero, where its magnitude is ≈0 by construction. The horizon-hold enters exactly there and holds a fixed window, so it realizes a near-zero-magnitude forecast and pays the spread → a small, consistent loss. The pass-through is profitable (at low sigma) precisely because it holds *through* the oracle's persistence between flips, riding the trend.

This cannot be fixed in the execution layer: an `ExecAlgorithm` cannot see the signal magnitude — only order timing and the `reduce_only` flag — so it cannot preferentially enter on strong forecasts.

## Recommendation

**Do not merge as-is.** Opened to record the experiment and the negative result for discussion.

## Files

- `execution_algos/simple_execution_strategy/execution_algorithm.py` — horizon-hold algorithm.
- `backtest_engine/backtest_low_level.py` — wire `horizon_seconds` into the `simple` algo (single source of truth: `config.yaml → strategy.kwargs.horizon_seconds`).

## Not included

- The `config.yaml` sigma change (separate, unresolved decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
