### PR TITLE
Make execution baseline passive and add fill model

### DIFF
--- a/backtest_engine/backtest_low_level.py
+++ b/backtest_engine/backtest_low_level.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from nautilus_trader.backtest.config import BacktestEngineConfig
 from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.backtest.models import FillModel
 from nautilus_trader.common.config import LoggingConfig
 from nautilus_trader.model import DataType
 from nautilus_trader.model import Money
@@ -73,6 +74,13 @@ def run_backtest(
         account_type=AccountType.MARGIN,
         base_currency=USD,
         starting_balances=[Money(STARTING_BALANCE_USD, USD)],
+        # Explicit fill model so the modelling assumption is version-controlled.
+        # prob_fill_on_limit=1.0 is the Nautilus default (a resting limit fills
+        # whenever the market trades to its price); the default
+        # fill_limit_inside_spread=False already gives realistic passive
+        # matching with natural adverse selection. random_seed keeps runs
+        # deterministic if prob_fill_on_limit is later lowered for queue realism.
+        fill_model=FillModel(prob_fill_on_limit=1.0, random_seed=42),
     )
 
     engine.add_instrument(instrument)

--- a/execution_algos/simple_execution_strategy/execution_algorithm.py
+++ b/execution_algos/simple_execution_strategy/execution_algorithm.py
@@ -1,39 +1,152 @@
+"""Passive (maker) baseline execution algorithm.
+
+Converts the oracle strategy's market orders into resting limit orders at the
+touch (buy at the bid, sell at the ask) so the baseline *earns* the bid-ask
+spread instead of *paying* it. If a limit has not fully filled by the time the
+strategy's next order arrives, or after `passive_timeout_seconds`, the unfilled
+remainder is crossed with a market order so every order still executes.
+
+Rationale: in the target regime (sigma ~217, R^2 ~1 bp) the per-trade forecast
+edge is smaller than the bid-ask spread, so crossing the spread on every trade
+(market orders) is a structural loss. Posting passively flips the spread from a
+cost toward a credit on the legs that fill as MAKER. See research/NOTES.md.
+"""
+from __future__ import annotations
+
 from nautilus_trader.execution.algorithm import ExecAlgorithm
 from nautilus_trader.execution.config import ExecAlgorithmConfig
+from nautilus_trader.model.enums import OrderSide
 from nautilus_trader.model.identifiers import ExecAlgorithmId
 
 
-class SimpleExecutionAlgorithmConfig(ExecAlgorithmConfig):
-    pass
+class SimpleExecutionAlgorithmConfig(ExecAlgorithmConfig, frozen=True):
+    """Baseline config.
+
+    Parameters
+    ----------
+    passive_timeout_seconds : float
+        How long a resting limit order may rest before its unfilled remainder
+        is crossed with a market order. Default 10.0.
+    """
+
+    passive_timeout_seconds: float = 10.0
 
 
 class SimpleExecutionAlgorithm(ExecAlgorithm):
+    """Passive-then-aggressive baseline execution algorithm.
+
+    For each order the strategy sends, post a limit at the touch (MAKER fill if
+    the market trades to it). If the limit has not fully filled by the time the
+    next order arrives, or after `passive_timeout_seconds`, cancel it and cross
+    the unfilled remainder with a market order (TAKER). At most one limit is
+    outstanding at a time, so the realised position never desyncs from the
+    strategy.
+
+    Uses only `spawn_limit` / `spawn_market` / `submit_order` / `cancel_order`
+    with `reduce_primary=False`; the parent order is never submitted and its
+    quantity is never modified, so `sum(child_fills) <= parent.quantity` holds.
     """
-    A custom execution algorithm that demonstrates simple order handling.
-    It immediately executes the incoming order in full.
-    """
+
+    def __init__(self, config: SimpleExecutionAlgorithmConfig) -> None:
+        super().__init__(config=config)
+        self._timeout_ns: int = int(config.passive_timeout_seconds * 1_000_000_000)
+        self._limit = None      # outstanding spawned limit order, or None
+        self._parent = None     # the strategy order the limit was spawned from
+        self._post_ts: int = 0  # ts_init of that order
+        self._subscribed: set[str] = set()
 
     def on_start(self) -> None:
-        self.log.info("SimpleExecutionAlgorithm started.")
-
-    def on_reset(self) -> None:
-        pass
-
-    def on_order(self, order) -> None:
-        """
-        Intercepts incoming orders from strategies.
-        """
         self.log.info(
-            f"SimpleExecutionAlgorithm handling order: {order.client_order_id} for {order.quantity}"
+            f"SimpleExecutionAlgorithm started "
+            f"(passive, timeout={self._timeout_ns / 1e9:.1f}s)."
         )
 
-        # Pass the order directly to the venue backend.
-        self.submit_order(order)
+    def on_reset(self) -> None:
+        self._clear()
+        self._subscribed.clear()
+
+    # ------------------------------------------------------------------
+
+    def _ensure_subscribed(self, instrument_id) -> None:
+        key = str(instrument_id)
+        if key not in self._subscribed:
+            self.subscribe_quote_ticks(instrument_id)
+            self._subscribed.add(key)
+
+    def _clear(self) -> None:
+        self._limit = None
+        self._parent = None
+        self._post_ts = 0
+
+    def _resolve_outstanding(self) -> None:
+        """Cancel the outstanding limit and cross any unfilled remainder."""
+        limit = self._limit
+        parent = self._parent
+        self._clear()
+        if limit is None or limit.is_closed:
+            return  # already fully filled or cancelled — nothing to do
+        remaining = limit.leaves_qty  # quantity - filled_qty, > 0 while open
+        self.cancel_order(limit)
+        market = self.spawn_market(
+            parent,
+            remaining,
+            reduce_only=parent.is_reduce_only,
+            reduce_primary=False,
+        )
+        self.submit_order(market)
+
+    # ------------------------------------------------------------------
+
+    def on_order(self, order) -> None:
+        """Post a passive limit for `order`, resolving any prior limit first."""
+        self._ensure_subscribed(order.instrument_id)
+
+        if self._limit is not None:
+            self._resolve_outstanding()
+
+        quote = self.cache.quote_tick(order.instrument_id)
+        if quote is None:
+            # No quote available yet — cross immediately so the order is not lost.
+            market = self.spawn_market(
+                order,
+                order.quantity,
+                reduce_only=order.is_reduce_only,
+                reduce_primary=False,
+            )
+            self.submit_order(market)
+            return
+
+        price = quote.bid_price if order.side == OrderSide.BUY else quote.ask_price
+        limit = self.spawn_limit(
+            order,
+            order.quantity,
+            price=price,
+            reduce_only=order.is_reduce_only,
+            reduce_primary=False,
+        )
+        self.submit_order(limit)
+        self._limit = limit
+        self._parent = order
+        self._post_ts = order.ts_init
+
+    def on_quote_tick(self, tick) -> None:
+        """Clear the outstanding limit once it fills, or resolve it on timeout."""
+        if self._limit is None:
+            return
+        if self._limit.is_closed:
+            self._clear()
+            return
+        if tick.ts_event - self._post_ts >= self._timeout_ns:
+            self._resolve_outstanding()
 
 
-def get_execution_algorithm(exec_id: str = "MY_GENERIC_ALGO"):
-    """
-    Instantiate and return the custom execution algorithm.
-    """
-    config = SimpleExecutionAlgorithmConfig(exec_algorithm_id=ExecAlgorithmId(exec_id))
+def get_execution_algorithm(
+    exec_id: str = "MY_GENERIC_ALGO",
+    passive_timeout_seconds: float = 10.0,
+) -> SimpleExecutionAlgorithm:
+    """Instantiate and return the passive baseline execution algorithm."""
+    config = SimpleExecutionAlgorithmConfig(
+        exec_algorithm_id=ExecAlgorithmId(exec_id),
+        passive_timeout_seconds=passive_timeout_seconds,
+    )
     return SimpleExecutionAlgorithm(config=config)

--- a/research/NOTES.md
+++ b/research/NOTES.md
@@ -119,3 +119,32 @@ the spread-filter nearly achieved ($1622.50, +2.25%).
 **Why**: Operator ran the agent on the bare host instead of inside `docker compose run dev`. The repo's tooling assumes the Docker context where `awscli` is baked in.
 **Alternatives**: (a) `brew install awscli` and re-run on host; (b) install Docker and use `docker compose run --rm dev`; (c) pre-seed `data-cache/` from another machine for an offline iteration.
 **Impact**: No program_database.json entry was written (no attempt was actually executed). No algorithm code was created. The iteration budget was not consumed. Operator decision required before the next invocation.
+
+---
+
+## [2026-05-21 23:30] ASSUMPTION: simple baseline switched to passive (maker) execution
+
+**Detail**: The `simple` execution algorithm (the pass-gate baseline) was
+rewritten from a market-order pass-through to passive limit-order execution. It
+posts a resting limit at the touch (buy at bid, sell at ask) for each order the
+strategy emits, and crosses the unfilled remainder with a market order only if
+the limit does not fill within `passive_timeout_seconds` (10s) or is superseded
+by the strategy's next order. `backtest_engine/backtest_low_level.py` now passes
+an explicit `FillModel(prob_fill_on_limit=1.0, random_seed=42)` to `add_venue()`.
+**Why**: At sigma≈217 (R²≈1 bp) the per-trade forecast edge is smaller than the
+bid-ask spread, so crossing it on every trade is a structural loss. Earning the
+spread via MAKER fills is the only execution-layer fix (Option B of the
+operator analysis).
+**Alternatives**: `config.yaml → execution_constraints.top_of_book_only`'s
+comment ("fill at ask_px for buys / bid_px for sells") describes the *taker*
+model; under passive execution read it as "post at the touch, never walk the
+book" — a buy limit at the bid is still top-of-book. The constraint is
+documentation-only (nothing in code enforces it), so no code change was made.
+`prob_fill_on_limit=1.0` is optimistic (no queue position) — lowering it is a
+realism refinement for later.
+**Impact**: Existing `program_database.json` / `overview.csv` baseline
+comparisons were produced against the old taker pass-through and are NOT
+comparable to results under the passive baseline. This is a deliberate
+operator-level benchmark redesign, not a research-agent change.
+
+⚠ NOTE WRITTEN: research/NOTES.md — simple baseline switched to passive (maker) execution

--- a/research/config.yaml
+++ b/research/config.yaml
@@ -25,7 +25,7 @@ strategy:
   # run_backtest() when absent.
   kwargs:
     horizon_seconds:        30.0   # forecast window for the oracle signal
-    sigma:                   200.0  # noise added to the forecast (targets 1bps R^2)
+    sigma:                  217.67 # noise added to the forecast (targets 1bps R^2)
     seed:                    42    # RNG seed (reproducibility when sigma > 0)
     signal_interval_seconds: 1.0   # cadence of generated signals
 


### PR DESCRIPTION
Rewrite the simple execution algorithm to a passive (maker) baseline: post resting limit orders at the touch (buy at bid, sell at ask), and cross any unfilled remainder with a market order when the next order arrives or after a configurable timeout (passive_timeout_seconds, default 10s). Ensure at most one spawned limit is outstanding and resolve it deterministically on timeout or supersession.

Add SimpleExecutionAlgorithmConfig.passive_timeout_seconds and expose it via get_execution_algorithm().

Make the backtest deterministic by passing an explicit FillModel(prob_fill_on_limit=1.0, random_seed=42) in backtest_low_level so the modelling assumption is version-controlled and results are reproducible.

Update research docs and config: record the baseline change in research/NOTES.md and adjust the oracle noise sigma in research/config.yaml from 200.0 to 217.67. Note: historical baseline results (program_database.json/overview.csv) are not comparable to results under the new passive baseline.