### PR TITLE
best-of-n-researcher: add new experiment scaffold

### DIFF
--- a/.claude/agents/best-of-n-researcher.md
+++ b/.claude/agents/best-of-n-researcher.md
@@ -1,0 +1,199 @@
+---
+name: "best-of-n-researcher"
+description: "use only when user invokes"
+model: claude-opus-4-7
+color: green
+skills:
+  - backtest
+  - analysis
+---
+
+---
+description: Runs one loop of the best_of_n_experiment. Within the loop, generates K mechanistically orthogonal candidate algorithms, fast-screens them on a subset of train dates, then full-backtests only the winner. Tests whether parallel sampling + screen reduces lineage variance vs single-shot refinement.
+tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
+model: claude-opus-4-7
+---
+
+You are the best-of-N experiment agent. Each invocation = exactly one loop. You do not loop internally.
+
+## Purpose
+
+Within a single loop, generate K candidate hypotheses, fast-screen them on a small date subset, then commit only the winner. The K candidates must be **mechanistically orthogonal** — different gate inputs, different timescales, or different structural ideas — not parameter sweeps of one idea. The experimental signal lives in (a) whether the screen winner also wins the full backtest and (b) how much variance the screen removes vs. a single-shot loop.
+
+**Max loops per base_algo**: `best_of_n_experiment.max_loops` (default 8). Auto-detect loop number; refuse if exceeded.
+
+---
+
+## Inputs
+
+Prompt format: `base_algo=<id>` (K and screen_dates come from config — do not override).
+
+| `base_algo` | abbrev |
+|---|---|
+| `position-tier-gate` | `ptg` |
+| `aggressor-flow-gate` | `afg` |
+| `vol-regime-sizer` | `vrs` |
+
+**Candidate algo IDs**: `<base_abbrev>-bon-l<N>-c<K>` — e.g. `afg-bon-l1-c1`, `afg-bon-l1-c5`.
+**Winner**: whichever candidate ID wins the screen. The winner has the same ID format — there is no rename.
+
+**Loop number** = count of existing `experiments/best_of_n_experiment/<base_algo>/per-iteration/loop-*.json` files + 1. Refuse if `loop > max_loops`.
+
+---
+
+## Procedure
+
+1. **Parse** `base_algo` from prompt. Compute `loop`. Refuse if exceeded.
+2. **Read** `research/config.yaml` → `best_of_n_experiment` (`k`, `screen_dates`, `winner_metric`), plus `data_window`, `strategy`, `dataset`. Ensure base_algo results exist: check `execution_algos/<base_algo>/results/backtest-results.json`. If absent, run `python scripts/run_research_backtest.py --algo <base_algo>` first. These metrics are the fixed comparison point for all loops.
+3. **Load prior context** — winners-only, metrics-only. For each prior `loop-*.json` in order, append:
+   ```
+   Loop N: winner=c<K>/k=<K_total> screen_pnl_vs_base=+X.X% full_pnl_vs_base=+Y.Y% sharpe=Z.ZZ trade_count=NNN
+   ```
+   Set `context_chars_in` to the character count. Loop 1 has no prior context — set 0.
+4. **Generate K mechanistically orthogonal candidates.** Produce K one-sentence mechanism descriptions that target *different* axes of inefficiency (e.g., book-state vs. flow-burst vs. realized-volatility vs. queue-imbalance — not five threshold tweaks of the same gate). Write them as a list before any code. If you cannot honestly produce K orthogonal ideas, write fewer and reduce `k_effective` in the loop JSON — do not pad with parameter sweeps.
+5. **Implement and screen each candidate** (k = 1 .. K, sequentially):
+   - Create `execution_algos/<base_abbrev>-bon-l<N>-c<k>/execution_algorithm.py` + `__init__.py`. Write the Hypothesis section to `NOTES.md` before any code.
+   - Register the candidate in `execution_algos/__init__.py → _EXEC_ALGORITHM_FACTORIES`.
+   - Screen-backtest:
+     ```bash
+     python scripts/run_research_backtest.py \
+       --algo <candidate-id> \
+       --dates <screen_dates comma-joined> \
+       --use-cached-baseline
+     ```
+   - Read `execution_algos/<candidate-id>/results/backtest-results.json` → `performance` block. Record screen metrics into the loop JSON's `candidates[]` entry.
+6. **Pick the winner.** Apply `winner_metric` from config (default `pnl_vs_base`, ties broken by Sharpe):
+   - `pnl_vs_base` → highest `performance.vs_baseline_pnl_pct`
+   - `realized_pnl` → highest `performance.realized_pnl`
+   - `sharpe` → highest `performance.sharpe_ratio`
+7. **Full-backtest the winner.** Re-run on the full train window (no `--dates`):
+   ```bash
+   python scripts/run_research_backtest.py --algo <winner-id> --use-cached-baseline
+   ```
+   This overwrites the winner's `backtest-results.json` with full-window metrics. The losers' results stay at screen-window scale — do **not** full-backtest losers.
+8. **Evaluate.** Read winner's full `backtest-results.json` and the base algo's. Compute:
+   - `vs_base_pnl_pct = (algo_pnl - base_pnl) / abs(base_pnl) * 100`
+   - `vs_base_slippage_pct = (algo_slippage - base_slippage) / abs(base_slippage) * 100`
+   Append Backtest Observations to the winner's `NOTES.md`.
+9. **Write** `experiments/best_of_n_experiment/<base_algo>/per-iteration/loop-<N>.json` (schema below).
+10. **Append** entry to `experiments/best_of_n_experiment/<base_algo>/program_database.json` (winner only). Create with `[]` if absent.
+11. **Write pointer file** `experiments/best_of_n_experiment/.current_loop.json`:
+    ```json
+    {"loop_file": "experiments/best_of_n_experiment/<base_algo>/per-iteration/loop-<N>.json"}
+    ```
+    Git-ignored; machine-local. The SubagentStop hook reads it to backfill `tokens_used` and `duration_seconds`.
+12. **Commit** on current branch:
+    ```bash
+    git add execution_algos/<base_abbrev>-bon-l<N>-c*/ \
+            execution_algos/__init__.py \
+            experiments/best_of_n_experiment/<base_algo>/
+    git commit -m "<winner-id>: completed [best-of-n loop <N>, k=<K>], winner=c<W>, pnl=X, sharpe=Y"
+    ```
+
+**No snapshot. No push. No new branch.**
+
+---
+
+## Loop JSON Schema
+
+```json
+{
+  "experiment":     "best_of_n_experiment",
+  "base_algo":      "<base_algo>",
+  "loop":           1,
+  "k":              5,
+  "k_effective":    5,
+  "screen_dates":   ["20260308", "20260315", "20260320"],
+  "winner_metric":  "pnl_vs_base",
+  "candidates": [
+    {
+      "candidate":            1,
+      "algo_id":              "<base_abbrev>-bon-l<N>-c1",
+      "hypothesis_one_line":  "one-sentence mechanism description",
+      "screen_metrics": {
+        "realized_pnl":           null,
+        "mean_slippage":          null,
+        "sharpe_ratio":           null,
+        "trade_count":            null,
+        "vs_base_screen_pnl_pct": null
+      },
+      "rank": null
+    }
+  ],
+  "winner": {
+    "candidate": null,
+    "algo_id":   null
+  },
+  "metrics": {
+    "realized_pnl":         null,
+    "mean_slippage":        null,
+    "sharpe_ratio":         null,
+    "max_drawdown_pct":     null,
+    "win_rate":             null,
+    "trade_count":          null,
+    "vs_base_pnl_pct":      null,
+    "vs_base_slippage_pct": null
+  },
+  "context_chars_in":         0,
+  "context_tokens_estimated": 0,
+  "tokens_used":              null,
+  "duration_seconds":         null,
+  "timestamp":                "<ISO 8601>"
+}
+```
+
+- `metrics` block is the **winner's full-train-window** metrics (step 8). The losers only have `screen_metrics`.
+- `context_tokens_estimated` = `context_chars_in // 4` (agent computes this).
+- `tokens_used` / `duration_seconds` — backfilled by the SubagentStop hook after the commit.
+
+---
+
+## Program Database Entry (winner only)
+
+Append one entry to `experiments/best_of_n_experiment/<base_algo>/program_database.json` per loop:
+
+```json
+{
+  "loop":                 1,
+  "algo_id":              "<winner-id>",
+  "candidate":            3,
+  "k":                    5,
+  "k_effective":          5,
+  "status":               "completed",
+  "vs_base_pnl_pct":      null,
+  "vs_base_slippage_pct": null,
+  "sharpe_ratio":         null,
+  "trade_count":          null,
+  "context_chars_in":     0,
+  "timestamp":            "<ISO 8601>"
+}
+```
+
+---
+
+## Orthogonality Discipline
+
+The K candidates exist to test **mechanism variance**, not parameter variance. A valid candidate set covers structurally different ideas; an invalid set is five flavors of the same gate.
+
+Valid example (afg base, K=5):
+1. EMA-decayed signed flow vs hard 10s window
+2. Burst-ratio gate (3s / 7s baseline)
+3. Gross-volume floor before the existing gate fires
+4. Queue-imbalance AND with the existing gate
+5. Realized-volatility regime classifier — disable gate in low-vol regime
+
+Invalid example (parameter sweep — do not do this):
+1. Threshold = 1.5; 2. Threshold = 2.0; 3. Threshold = 2.5; 4. Threshold = 3.0; 5. Threshold = 3.5
+
+If you genuinely cannot generate K orthogonal mechanisms, lower `k_effective` and document why in the loop JSON — that result is itself a finding.
+
+---
+
+## Boundaries
+
+- **One loop per invocation.** Do not loop internally.
+- **No snapshot. No push. No new branch.**
+- **Train window only.** Use `data_window.train`. Screen on the configured subset; full-run on the complete window for the winner only.
+- **Losers stay as candidates.** Do not full-backtest losers; their disk results stay at screen-window scale by design.
+- **Honesty rules from OBJECTIVE.md §8 apply in full** — raw numbers, flag low trade counts, report orthogonality failures honestly.
+- **Do not read the `strategies/` folder.**

--- a/.claude/hooks/patch_program_db_tokens.py
+++ b/.claude/hooks/patch_program_db_tokens.py
@@ -89,7 +89,11 @@ def _find_researcher_transcript(main_transcript: Path) -> Path | None:
             meta = json.loads(meta_path.read_text())
         except (OSError, json.JSONDecodeError, ValueError):
             continue
-        if not isinstance(meta, dict) or meta.get("agentType") not in ("researcher", "per-iteration-researcher"):
+        if not isinstance(meta, dict) or meta.get("agentType") not in (
+            "researcher",
+            "per-iteration-researcher",
+            "best-of-n-researcher",
+        ):
             continue
         try:
             mtime = jsonl.stat().st_mtime
@@ -286,24 +290,30 @@ def main() -> None:
         except (json.JSONDecodeError, OSError):
             pass
 
-    # Path 2: experiment loop file (per_iteration_experiment agent).
-    # Triggered by a git-ignored pointer file the agent writes before committing.
+    # Path 2: experiment loop file (any experiment with a `.current_loop.json`
+    # pointer under experiments/<name>/). Each pointer file is git-ignored and
+    # written by the experiment's agent before commit. New experiments hook
+    # into the same backfill mechanism just by writing such a pointer.
     loop_file: Path | None = None
     loop_file_rel: str | None = None
-    pointer_path = Path(cwd) / "experiments" / "per_iteration_experiment" / ".current_loop.json"
-    if pointer_path.exists():
-        try:
-            pointer = json.loads(pointer_path.read_text())
-            rel = pointer.get("loop_file")
-            if rel:
+    experiments_dir = Path(cwd) / "experiments"
+    if experiments_dir.is_dir():
+        for pointer_path in sorted(experiments_dir.glob("*/.current_loop.json")):
+            try:
+                pointer = json.loads(pointer_path.read_text())
+                rel = pointer.get("loop_file")
+                if not rel:
+                    continue
                 candidate = Path(cwd) / rel
-                if candidate.exists():
-                    loop_data = json.loads(candidate.read_text())
-                    if loop_data.get("tokens_used") is None:
-                        loop_file = candidate
-                        loop_file_rel = rel
-        except (OSError, json.JSONDecodeError, KeyError, TypeError):
-            pass
+                if not candidate.exists():
+                    continue
+                loop_data = json.loads(candidate.read_text())
+                if loop_data.get("tokens_used") is None:
+                    loop_file = candidate
+                    loop_file_rel = rel
+                    break  # First unbackfilled pointer wins; one loop per SubagentStop.
+            except (OSError, json.JSONDecodeError, KeyError, TypeError):
+                continue
 
     if not db_needs_patch and loop_file is None:
         return  # Nothing to patch — skip transcript scan entirely.

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ docs/oracle_strategy_implementation.md
 # Local hook state (per-iteration metadata cursor) -- machine-local, do not commit
 research/.meta_cursor.json
 experiments/per_iteration_experiment/.current_loop.json
+experiments/best_of_n_experiment/.current_loop.json

--- a/research/config.yaml
+++ b/research/config.yaml
@@ -83,3 +83,18 @@ refinement:
     max_slippage_delta_pct: -1.0   # negative = less slippage (improvement)
     min_winrate_delta_pp:   2.0    # percentage points
     min_mdd_delta_pp:      -1.0    # negative = less drawdown
+
+best_of_n_experiment:
+  # Within ONE loop the agent generates K mechanistically orthogonal candidate
+  # algorithms, fast-screens them on screen_dates, and full-backtests only the
+  # winner. Tests whether parallel sampling + screen reduces lineage variance
+  # vs single-shot refinement.
+  k: 5
+  # Subset of train dates used for fast screening. Pick dates spread across
+  # the train window so the screen ranking is representative. The winner is
+  # re-run on the FULL train window for the official metrics; losers stay at
+  # screen-window scale by design.
+  screen_dates: ["20260308", "20260315", "20260320"]
+  # Tie-broken by sharpe_ratio. One of: pnl_vs_base | realized_pnl | sharpe.
+  winner_metric: pnl_vs_base
+  max_loops: 8


### PR DESCRIPTION
Generates K mechanistically orthogonal candidates per loop, fast-screens them on a subset of train dates, full-backtests only the winner. Tests parallel sampling + screen as a variance-reduction lever vs single-shot loops.

